### PR TITLE
Fix release action ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Function-Mesh Release
 
 on:
   release:
+    types: [created]
 
 jobs:
   upload:


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Currently, when we trigger the release button, multiple actions will be triggered. In fact, we only need to create a release event.