### PR TITLE
Fix release action ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         id: go
 
       - name: setup kubebuilder 2.3.1
-        uses: RyanSiu1995/kubebuilder-action@v1
+        uses: RyanSiu1995/kubebuilder-action@v1.1
         with:
           version: 2.3.1
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

The https://github.com/RyanSiu1995/kubebuilder-action Upgrade the version to `v1.1` to avoid the `add-path` error.

So we need to fix the issue.

Fix release action ci