### PR TITLE
add extraDependenciesDir for java runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin
 
 # editor and IDE paraphernalia
 .idea
+*.iml
 *.swp
 *.swo
 *~

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -84,8 +84,9 @@ type Runtime struct {
 }
 
 type JavaRuntime struct {
-	Jar         string `json:"jar,omitempty"`
-	JarLocation string `json:"jarLocation,omitempty"`
+	Jar                  string `json:"jar,omitempty"`
+	JarLocation          string `json:"jarLocation,omitempty"`
+	ExtraDependenciesDir string `json:"extraDependenciesDir,omitempty"`
 }
 
 type PythonRuntime struct {

--- a/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
@@ -132,6 +132,8 @@ spec:
                     type: object
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:
@@ -2360,6 +2362,8 @@ spec:
                     type: object
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:
@@ -4455,6 +4459,8 @@ spec:
                     type: string
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:

--- a/config/crd/bases/compute.functionmesh.io_functions.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functions.yaml
@@ -133,6 +133,8 @@ spec:
               type: object
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:

--- a/config/crd/bases/compute.functionmesh.io_sinks.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sinks.yaml
@@ -127,6 +127,8 @@ spec:
               type: object
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:

--- a/config/crd/bases/compute.functionmesh.io_sources.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sources.yaml
@@ -49,6 +49,8 @@ spec:
               type: string
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:

--- a/config/samples/compute_v1alpha1_function.yaml
+++ b/config/samples/compute_v1alpha1_function.yaml
@@ -59,6 +59,7 @@ spec:
   java:
     jar: pulsar-functions-api-examples.jar
     jarLocation: public/default/nlu-test-java-function
+    extraDependenciesDir: random-dir/
     # use package name:
     # jarLocation: function://public/default/nul-test-java-function@v1
   # to be delete & use admission hook

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -98,23 +98,25 @@ func makeFunctionLabels(function *v1alpha1.Function) map[string]string {
 }
 
 func makeFunctionCommand(function *v1alpha1.Function) []string {
-	if function.Spec.Java != nil {
-		if function.Spec.Java.Jar != "" {
-			return MakeJavaFunctionCommand(function.Spec.Java.JarLocation, function.Spec.Java.Jar,
-				function.Spec.Name, function.Spec.ClusterName, generateFunctionDetailsInJSON(function),
-				function.Spec.Resources.Requests.Memory().String(), function.Spec.Pulsar.AuthConfig != "")
-		}
+	spec := function.Spec
 
-	} else if function.Spec.Golang != nil {
-		if function.Spec.Golang.Go != "" {
-			return MakeGoFunctionCommand(function.Spec.Golang.GoLocation, function.Spec.Golang.Go,
-				function)
+	if spec.Java != nil {
+		if spec.Java.Jar != "" {
+			return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
+				spec.Name, spec.ClusterName, generateFunctionDetailsInJSON(function),
+				spec.Resources.Requests.Memory().String(), spec.Java.ExtraDependenciesDir,
+				spec.Pulsar.AuthConfig != "")
 		}
-	} else if function.Spec.Python != nil {
-		if function.Spec.Python.Py != "" {
-			return MakePythonFunctionCommand(function.Spec.Python.PyLocation, function.Spec.Python.Py,
-				function.Spec.Name, function.Spec.ClusterName, generateFunctionDetailsInJSON(function),
-				function.Spec.Pulsar.AuthConfig != "")
+	} else if spec.Python != nil {
+		if spec.Python.Py != "" {
+			return MakePythonFunctionCommand(spec.Python.PyLocation, spec.Python.Py,
+				spec.Name, spec.ClusterName, generateFunctionDetailsInJSON(function),
+				spec.Pulsar.AuthConfig != "")
+		}
+	} else if spec.Golang != nil {
+		if spec.Golang.Go != "" {
+			return MakeGoFunctionCommand(spec.Golang.GoLocation, spec.Golang.Go,
+				function)
 		}
 	}
 

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -90,10 +90,11 @@ func makeSinkVolumeMounts(sink *v1alpha1.Sink) []corev1.VolumeMount {
 }
 
 func MakeSinkCommand(sink *v1alpha1.Sink) []string {
-	return MakeJavaFunctionCommand(sink.Spec.Java.JarLocation, sink.Spec.Java.Jar,
-		sink.Spec.Name, sink.Spec.ClusterName, generateSinkDetailsInJSON(sink),
-		sink.Spec.Resources.Requests.Memory().ToDec().String(),
-		sink.Spec.Pulsar.AuthConfig != "")
+	spec := sink.Spec
+	return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
+		spec.Name, spec.ClusterName, generateSinkDetailsInJSON(sink),
+		spec.Resources.Requests.Memory().ToDec().String(), spec.Java.ExtraDependenciesDir,
+		spec.Pulsar.AuthConfig != "")
 }
 
 func generateSinkDetailsInJSON(sink *v1alpha1.Sink) string {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -90,10 +90,11 @@ func makeSourceVolumeMounts(source *v1alpha1.Source) []corev1.VolumeMount {
 }
 
 func makeSourceCommand(source *v1alpha1.Source) []string {
-	return MakeJavaFunctionCommand(source.Spec.Java.JarLocation, source.Spec.Java.Jar,
-		source.Spec.Name, source.Spec.ClusterName, generateSourceDetailsInJSON(source),
-		source.Spec.Resources.Requests.Memory().ToDec().String(),
-		source.Spec.Pulsar.AuthConfig != "")
+	spec := source.Spec
+	return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
+		spec.Name, spec.ClusterName, generateSourceDetailsInJSON(source),
+		spec.Resources.Requests.Memory().ToDec().String(), spec.Java.ExtraDependenciesDir,
+		spec.Pulsar.AuthConfig != "")
 }
 
 func generateSourceDetailsInJSON(source *v1alpha1.Source) string {

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -130,6 +130,8 @@ spec:
                     type: object
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:
@@ -2358,6 +2360,8 @@ spec:
                     type: object
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:
@@ -4453,6 +4457,8 @@ spec:
                     type: string
                   java:
                     properties:
+                      extraDependenciesDir:
+                        type: string
                       jar:
                         type: string
                       jarLocation:
@@ -6755,6 +6761,8 @@ spec:
               type: object
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:
@@ -9047,6 +9055,8 @@ spec:
               type: object
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:
@@ -11206,6 +11216,8 @@ spec:
               type: string
             java:
               properties:
+                extraDependenciesDir:
+                  type: string
                 jar:
                   type: string
                 jarLocation:


### PR DESCRIPTION
1. add the support for `extraDependenciesDir` for java runtime. Solves #153 
2. refactor code to reduce code duplication