### PR TITLE
don't assign default zero value to maxReplicas

### DIFF
--- a/api/v1alpha1/function_webhook.go
+++ b/api/v1alpha1/function_webhook.go
@@ -51,11 +51,6 @@ func (r *Function) Default() {
 		r.Spec.Replicas = &zeroVal
 	}
 
-	if r.Spec.MaxReplicas == nil {
-		zeroVal := int32(0)
-		r.Spec.MaxReplicas = &zeroVal
-	}
-
 	if r.Spec.AutoAck == nil {
 		trueVal := true
 		r.Spec.AutoAck = &trueVal

--- a/api/v1alpha1/sink_webhook.go
+++ b/api/v1alpha1/sink_webhook.go
@@ -51,11 +51,6 @@ func (r *Sink) Default() {
 		r.Spec.Replicas = &zeroVal
 	}
 
-	if r.Spec.MaxReplicas == nil {
-		zeroVal := int32(0)
-		r.Spec.MaxReplicas = &zeroVal
-	}
-
 	if r.Spec.AutoAck == nil {
 		trueVal := true
 		r.Spec.AutoAck = &trueVal

--- a/api/v1alpha1/source_webhook.go
+++ b/api/v1alpha1/source_webhook.go
@@ -51,11 +51,6 @@ func (r *Source) Default() {
 		r.Spec.Replicas = &zeroVal
 	}
 
-	if r.Spec.MaxReplicas == nil {
-		zeroVal := int32(0)
-		r.Spec.MaxReplicas = &zeroVal
-	}
-
 	//if r.Spec.AutoAck == nil {
 	//	trueVal := true
 	//	r.Spec.AutoAck = &trueVal

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -165,7 +165,7 @@ func (r *FunctionReconciler) ApplyFunctionService(ctx context.Context, req ctrl.
 
 func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if *function.Spec.MaxReplicas == 0 {
+	if function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -202,7 +202,7 @@ func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Re
 
 func (r *FunctionReconciler) ApplyFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if *function.Spec.MaxReplicas == 0 {
+	if function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -161,7 +161,7 @@ func (r *SinkReconciler) ApplySinkService(ctx context.Context, req ctrl.Request,
 }
 
 func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if *sink.Spec.MaxReplicas == 0 {
+	if sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -197,7 +197,7 @@ func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, s
 }
 
 func (r *SinkReconciler) ApplySinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if *sink.Spec.MaxReplicas == 0 {
+	if sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -163,7 +163,7 @@ func (r *SourceReconciler) ApplySourceService(ctx context.Context, req ctrl.Requ
 }
 
 func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if *source.Spec.MaxReplicas == 0 {
+	if source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -199,7 +199,7 @@ func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Reques
 }
 
 func (r *SourceReconciler) ApplySourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if *source.Spec.MaxReplicas == 0 {
+	if source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}


### PR DESCRIPTION
1. delete the hook code assign zero to maxReplicas
2. controller check if maxReplicas is nil to determine whether create HPA object
3. the validation logic (maxReplicas should be >= replicas) in webhook is still kept