### PR TITLE
allow set input topics with `--custom-schema-inputs` instead of `--inputs` 

### DIFF
--- a/mesh-worker-service/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
+++ b/mesh-worker-service/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
@@ -109,7 +109,16 @@ public class FunctionsUtil {
             v1alpha1FunctionSpecInput.setTypeClassName(customRuntimeOptions.getInputTypeClassName());
         }
 
-        v1alpha1FunctionSpecInput.setTopics(new ArrayList<>(functionConfig.getInputs()));
+        if (functionConfig.getInputs() != null) {
+            v1alpha1FunctionSpecInput.setTopics(new ArrayList<>(functionConfig.getInputs()));
+        }
+
+        if ((v1alpha1FunctionSpecInput.getTopics() == null || v1alpha1FunctionSpecInput.getTopics().size() == 0) &&
+                (v1alpha1FunctionSpecInput.getSourceSpecs() == null || v1alpha1FunctionSpecInput.getSourceSpecs().size() == 0)
+        ) {
+            log.warn("invalid FunctionSpecInput {}", v1alpha1FunctionSpecInput);
+            throw new RestException(Response.Status.BAD_REQUEST, "invalid FunctionSpecInput");
+        }
         v1alpha1FunctionSpec.setInput(v1alpha1FunctionSpecInput);
 
         if (!StringUtils.isEmpty(functionDetails.getSource().getSubscriptionName())) {

--- a/mesh-worker-service/src/main/java/io/functionmesh/compute/util/SinksUtil.java
+++ b/mesh-worker-service/src/main/java/io/functionmesh/compute/util/SinksUtil.java
@@ -164,7 +164,16 @@ public class SinksUtil {
             }
         }
 
-        v1alpha1SinkSpecInput.setTopics(new ArrayList<>(sinkConfig.getInputs()));
+        if (sinkConfig.getInputs() != null) {
+            v1alpha1SinkSpecInput.setTopics(new ArrayList<>(sinkConfig.getInputs()));
+        }
+
+        if ((v1alpha1SinkSpecInput.getTopics() == null || v1alpha1SinkSpecInput.getTopics().size() == 0) &&
+                (v1alpha1SinkSpecInput.getSourceSpecs() == null || v1alpha1SinkSpecInput.getSourceSpecs().size() == 0)
+        ) {
+            log.warn("invalid SinkSpecInput {}", v1alpha1SinkSpecInput);
+            throw new RestException(Response.Status.BAD_REQUEST, "invalid SinkSpecInput");
+        }
         v1alpha1SinkSpec.setInput(v1alpha1SinkSpecInput);
 
         if (Strings.isNotEmpty(functionDetails.getSource().getSubscriptionName())) {


### PR DESCRIPTION
fix #194

currently, user must use `--inputs` to set function or sink's input topics, even with `--custom-schema-inputs` or other related params provided. This PR allows `--inputs` to be null and added validations on input spec.