### PR TITLE
fix service name observe

### DIFF
--- a/controllers/function.go
+++ b/controllers/function.go
@@ -126,11 +126,12 @@ func (r *FunctionReconciler) ObserveFunctionService(ctx context.Context, req ctr
 	}
 
 	svc := &corev1.Service{}
+	svcName := spec.MakeHeadlessServiceName(spec.MakeFunctionObjectMeta(function).Name)
 	err := r.Get(ctx, types.NamespacedName{Namespace: function.Namespace,
-		Name: spec.MakeFunctionObjectMeta(function).Name}, svc)
+		Name: svcName}, svc)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("service is not created...", "Name", function.Name)
+			r.Log.Info("service is not created...", "Name", function.Name, "ServiceName", svcName)
 			return nil
 		}
 		return err

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -113,12 +113,13 @@ func (r *SinkReconciler) ObserveSinkService(ctx context.Context, req ctrl.Reques
 	}
 
 	svc := &corev1.Service{}
+	svcName := spec.MakeHeadlessServiceName(spec.MakeSinkObjectMeta(sink).Name)
 	err := r.Get(ctx, types.NamespacedName{Namespace: sink.Namespace,
-		Name: spec.MakeSinkObjectMeta(sink).Name}, svc)
+		Name: svcName}, svc)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			condition.Action = v1alpha1.Create
-			r.Log.Info("service is not created...", "Name", sink.Name)
+			r.Log.Info("service is not created...", "Name", sink.Name, "ServiceName", svcName)
 		} else {
 			sink.Status.Conditions[v1alpha1.Service] = condition
 			return err

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -115,12 +115,13 @@ func (r *SourceReconciler) ObserveSourceService(ctx context.Context, req ctrl.Re
 	}
 
 	svc := &corev1.Service{}
+	svcName := spec.MakeHeadlessServiceName(spec.MakeSourceObjectMeta(source).Name)
 	err := r.Get(ctx, types.NamespacedName{Namespace: source.Namespace,
-		Name: spec.MakeSourceObjectMeta(source).Name}, svc)
+		Name: svcName}, svc)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			condition.Action = v1alpha1.Create
-			r.Log.Info("service is not created...", "Name", source.Name)
+			r.Log.Info("service is not created...", "Name", source.Name, "ServiceName", svcName)
 		} else {
 			source.Status.Conditions[v1alpha1.Service] = condition
 			return err

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -91,6 +91,7 @@ func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev
 	}
 }
 
+// MakeHeadlessServiceName changes the name of service to headless style
 func MakeHeadlessServiceName(serviceName string) string {
 	return fmt.Sprintf("%s-headless", serviceName)
 }

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -72,7 +72,7 @@ var MetricsPort = corev1.ContainerPort{
 }
 
 func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev1.Service {
-	objectMeta.Name = makeHeadlessServiceName(objectMeta.Name)
+	objectMeta.Name = MakeHeadlessServiceName(objectMeta.Name)
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -91,7 +91,7 @@ func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev
 	}
 }
 
-func makeHeadlessServiceName(serviceName string) string {
+func MakeHeadlessServiceName(serviceName string) string {
 	return fmt.Sprintf("%s-headless", serviceName)
 }
 
@@ -127,7 +127,7 @@ func MakeStatefulSet(objectMeta *metav1.ObjectMeta, replicas *int32, container *
 		},
 		ObjectMeta: *objectMeta,
 		Spec: *MakeStatefulSetSpec(replicas, container, volumes, labels, policy,
-			makeHeadlessServiceName(objectMeta.Name)),
+			MakeHeadlessServiceName(objectMeta.Name)),
 	}
 }
 

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -45,7 +45,7 @@ func MakeSinkStatefulSet(sink *v1alpha1.Sink) *appsv1.StatefulSet {
 
 func MakeSinkServiceName(sink *v1alpha1.Sink) string {
 	objectMeta := MakeSinkObjectMeta(sink)
-	return makeHeadlessServiceName(objectMeta.Name)
+	return MakeHeadlessServiceName(objectMeta.Name)
 }
 
 func MakeSinkObjectMeta(sink *v1alpha1.Sink) *metav1.ObjectMeta {


### PR DESCRIPTION
the previous PR makes the service with `-headless` postfix in name, but the observer is not updated so it will cause a false alarm of service observer