### PR TITLE
fix NPE when not set AutoAck

### DIFF
--- a/controllers/spec/utils.go
+++ b/controllers/spec/utils.go
@@ -31,6 +31,7 @@ import (
 )
 
 func convertFunctionDetails(function *v1alpha1.Function) *proto.FunctionDetails {
+
 	return &proto.FunctionDetails{
 		Tenant:               function.Spec.Tenant,
 		Namespace:            function.Namespace,
@@ -41,8 +42,8 @@ func convertFunctionDetails(function *v1alpha1.Function) *proto.FunctionDetails 
 		UserConfig:           getUserConfig(function.Spec.FuncConfig),
 		SecretsMap:           marshalSecretsMap(function.Spec.SecretsMap),
 		Runtime:              proto.FunctionDetails_JAVA,
-		AutoAck:              *function.Spec.AutoAck,
-		Parallelism:          *function.Spec.Replicas,
+		AutoAck:              getBoolFromPtrOrDefault(function.Spec.AutoAck, true),
+		Parallelism:          getInt32FromPtrOrDefault(function.Spec.Replicas, 1),
 		Source:               generateFunctionInputSpec(function),
 		Sink:                 generateFunctionOutputSpec(function),
 		Resources:            generateResource(function.Spec.Resources.Requests),
@@ -72,8 +73,8 @@ func convertGoFunctionConfs(function *v1alpha1.Function) *GoFunctionConf {
 		ProcessingGuarantees: int32(convertProcessingGuarantee(function.Spec.ProcessingGuarantee)),
 		//SecretsMap:                  marshalSecretsMap(function.Spec.SecretsMap),
 		Runtime:                     int32(proto.FunctionDetails_GO),
-		AutoACK:                     *function.Spec.AutoAck,
-		Parallelism:                 *function.Spec.Replicas,
+		AutoACK:                     getBoolFromPtrOrDefault(function.Spec.AutoAck, true),
+		Parallelism:                 getInt32FromPtrOrDefault(function.Spec.Replicas, 1),
 		TimeoutMs:                   uint64(function.Spec.Timeout),
 		SubscriptionName:            function.Spec.SubscriptionName,
 		CleanupSubscription:         function.Spec.CleanupSubscription,
@@ -212,7 +213,7 @@ func convertSourceDetails(source *v1alpha1.Source) *proto.FunctionDetails {
 		SecretsMap:           marshalSecretsMap(source.Spec.SecretsMap),
 		Runtime:              proto.FunctionDetails_JAVA,
 		AutoAck:              true,
-		Parallelism:          *source.Spec.Replicas,
+		Parallelism:          getInt32FromPtrOrDefault(source.Spec.Replicas, 1),
 		Source:               generateSourceInputSpec(source),
 		Sink:                 generateSourceOutputSpec(source),
 		Resources:            generateResource(source.Spec.Resources.Requests),
@@ -254,6 +255,22 @@ func generateSourceOutputSpec(source *v1alpha1.Source) *proto.SinkSpec {
 	}
 }
 
+func getBoolFromPtrOrDefault(ptr *bool, val bool) bool {
+	ret := val
+	if ptr != nil {
+		ret = *ptr
+	}
+	return ret
+}
+
+func getInt32FromPtrOrDefault(ptr *int32, val int32) int32 {
+	ret := val
+	if ptr != nil {
+		ret = *ptr
+	}
+	return ret
+}
+
 func convertSinkDetails(sink *v1alpha1.Sink) *proto.FunctionDetails {
 	return &proto.FunctionDetails{
 		Tenant:               sink.Spec.Tenant,
@@ -264,8 +281,8 @@ func convertSinkDetails(sink *v1alpha1.Sink) *proto.FunctionDetails {
 		ProcessingGuarantees: convertProcessingGuarantee(sink.Spec.ProcessingGuarantee),
 		SecretsMap:           marshalSecretsMap(sink.Spec.SecretsMap),
 		Runtime:              proto.FunctionDetails_JAVA,
-		AutoAck:              *sink.Spec.AutoAck,
-		Parallelism:          *sink.Spec.Replicas,
+		AutoAck:              getBoolFromPtrOrDefault(sink.Spec.AutoAck, true),
+		Parallelism:          getInt32FromPtrOrDefault(sink.Spec.Replicas, 1),
 		Source:               generateSinkInputSpec(sink),
 		Sink:                 generateSinkOutputSpec(sink),
 		Resources:            generateResource(sink.Spec.Resources.Requests),

--- a/controllers/spec/utils.go
+++ b/controllers/spec/utils.go
@@ -255,22 +255,6 @@ func generateSourceOutputSpec(source *v1alpha1.Source) *proto.SinkSpec {
 	}
 }
 
-func getBoolFromPtrOrDefault(ptr *bool, val bool) bool {
-	ret := val
-	if ptr != nil {
-		ret = *ptr
-	}
-	return ret
-}
-
-func getInt32FromPtrOrDefault(ptr *int32, val int32) int32 {
-	ret := val
-	if ptr != nil {
-		ret = *ptr
-	}
-	return ret
-}
-
 func convertSinkDetails(sink *v1alpha1.Sink) *proto.FunctionDetails {
 	return &proto.FunctionDetails{
 		Tenant:               sink.Spec.Tenant,
@@ -384,4 +368,20 @@ func sanitizeVolumeName(name string) string {
 
 func makeJobName(name, suffix string) string {
 	return fmt.Sprintf("%s-%s", name, suffix)
+}
+
+func getBoolFromPtrOrDefault(ptr *bool, val bool) bool {
+	ret := val
+	if ptr != nil {
+		ret = *ptr
+	}
+	return ret
+}
+
+func getInt32FromPtrOrDefault(ptr *int32, val int32) int32 {
+	ret := val
+	if ptr != nil {
+		ret = *ptr
+	}
+	return ret
 }

--- a/controllers/spec/utils_test.go
+++ b/controllers/spec/utils_test.go
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetValFromPtrOrDefault(t *testing.T) {
+	boolVal := true
+	boolPtr := &boolVal
+	assert.Equal(t, getBoolFromPtrOrDefault(boolPtr, false), boolVal)
+	assert.Equal(t, getBoolFromPtrOrDefault(nil, boolVal), boolVal)
+
+	var int32Val int32 = 100
+	int32Ptr := &int32Val
+	assert.Equal(t, getInt32FromPtrOrDefault(int32Ptr, 200), int32Val)
+	assert.Equal(t, getInt32FromPtrOrDefault(nil, int32Val), int32Val)
+}


### PR DESCRIPTION
Fix https://github.com/streamnative/function-mesh/issues/218
This PR fixes NPE when user not set AutoAck or Replica in Function / Sink / Source spec.
With this PR, a default value is set to AutoAck = true and Replica = 1 if the user not set.