### PR TITLE
upgrade to `k8s.io/api/autoscaling/v2beta2`

### DIFF
--- a/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
@@ -43,8 +43,8 @@ spec:
   autoAck: true
   pod:
     builtinAutoscaler:
-      - "AverageUtilizationCPUPercent20"
-      - "AverageUtilizationMemoryPercent20"
+      - AverageUtilizationCPUPercent20
+      - AverageUtilizationMemoryPercent20
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
@@ -41,9 +41,10 @@ spec:
   # to be delete & use admission hook
   clusterName: test
   autoAck: true
-  builtinAutoscaler:
-    - "AverageUtilizationCPUPercent80"
-    - "AverageUtilizationMemoryPercent20"
+  pod:
+    builtinAutoscaler:
+      - "AverageUtilizationCPUPercent80"
+      - "AverageUtilizationMemoryPercent20"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
@@ -43,7 +43,7 @@ spec:
   autoAck: true
   pod:
     builtinAutoscaler:
-      - "AverageUtilizationCPUPercent80"
+      - "AverageUtilizationCPUPercent20"
       - "AverageUtilizationMemoryPercent20"
 ---
 apiVersion: v1

--- a/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
@@ -1,0 +1,75 @@
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: function-builtin-hpa-sample
+  namespace: default
+spec:
+  image: streamnative/pulsar-functions-java-sample:2.8.0.7
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  forwardSourceMessageProperty: true
+  MaxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 5
+  logTopic: persistent://public/default/logging-function-logs
+  input:
+    topics:
+      - persistent://public/default/input-java-topic
+    typeClassName: java.lang.String
+  output:
+    topic: persistent://public/default/output-java-topic
+    typeClassName: java.lang.String
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1.1G
+  # each secret will be loaded ad an env variable from the `path` secret with the `key` in that secret in the name of `name`
+  secretsMap:
+    "name":
+      path: "test-secret"
+      key: "username"
+    "pwd":
+      path: "test-secret"
+      key: "password"
+  pulsar:
+    pulsarConfig: "test-pulsar"
+    #authConfig: "test-auth"
+  java:
+    jar: /pulsar/examples/api-examples.jar
+  # to be delete & use admission hook
+  clusterName: test
+  autoAck: true
+  builtinAutoscaler:
+    - "AverageUtilizationCPUPercent80"
+    - "AverageUtilizationMemoryPercent20"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-pulsar
+data:
+  webServiceURL: http://sn-platform-pulsar-broker.default.svc.cluster.local:8080
+  brokerServiceURL: pulsar://sn-platform-pulsar-broker.default.svc.cluster.local:6650
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: test-auth
+#data:
+#  clientAuthenticationPlugin: "abc"
+#  clientAuthenticationParameters: "xyz"
+#  tlsTrustCertsFilePath: "uvw"
+#  useTls: "true"
+#  tlsAllowInsecureConnection: "false"
+#  tlsHostnameVerificationEnable: "true"
+---
+apiVersion: v1
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque

--- a/.ci/clusters/compute_v1alpha1_function_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_hpa.yaml
@@ -41,13 +41,14 @@ spec:
   # to be delete & use admission hook
   clusterName: test
   autoAck: true
-  autoScalingMetrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
+  pod:
+    autoScalingMetrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/.ci/clusters/compute_v1alpha1_function_hpa.yaml
+++ b/.ci/clusters/compute_v1alpha1_function_hpa.yaml
@@ -1,0 +1,79 @@
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: function-hpa-sample
+  namespace: default
+spec:
+  image: streamnative/pulsar-functions-java-sample:2.8.0.7
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  forwardSourceMessageProperty: true
+  MaxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 5
+  logTopic: persistent://public/default/logging-function-logs
+  input:
+    topics:
+    - persistent://public/default/input-java-topic
+    typeClassName: java.lang.String
+  output:
+    topic: persistent://public/default/output-java-topic
+    typeClassName: java.lang.String
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1.1G
+  # each secret will be loaded ad an env variable from the `path` secret with the `key` in that secret in the name of `name`
+  secretsMap:
+    "name":
+        path: "test-secret"
+        key: "username"
+    "pwd":
+        path: "test-secret"
+        key: "password"
+  pulsar:
+    pulsarConfig: "test-pulsar"
+    #authConfig: "test-auth"
+  java:
+    jar: /pulsar/examples/api-examples.jar
+  # to be delete & use admission hook
+  clusterName: test
+  autoAck: true
+  autoScalingMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-pulsar
+data:
+  webServiceURL: http://sn-platform-pulsar-broker.default.svc.cluster.local:8080
+  brokerServiceURL: pulsar://sn-platform-pulsar-broker.default.svc.cluster.local:6650
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: test-auth
+#data:
+#  clientAuthenticationPlugin: "abc"
+#  clientAuthenticationParameters: "xyz"
+#  tlsTrustCertsFilePath: "uvw"
+#  useTls: "true"
+#  tlsAllowInsecureConnection: "false"
+#  tlsHostnameVerificationEnable: "true"
+---
+apiVersion: v1
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque

--- a/.ci/deploy_pulsar_cluster.sh
+++ b/.ci/deploy_pulsar_cluster.sh
@@ -40,6 +40,9 @@ fi
 # install storage provisioner
 ci::install_storage_provisioner
 
+# install metrics server
+ci::install_metrics_server
+
 # install pulsar chart
 ci::install_pulsar_charts "$VALUES_FILE"
 

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -64,6 +64,13 @@ function ci::install_storage_provisioner() {
     echo "Successfully installed the local storage provisioner."
 }
 
+function ci::install_metrics_server() {
+    echo "install metrics-server"
+    ${KUBECTL} apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+    ${KUBECTL} patch deployment metrics-server -n kube-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls","--kubelet-preferred-address-types=InternalIP"]}]}}}}'
+    echo "Successfully installed the metrics-server."
+}
+
 function ci::install_pulsar_charts() {
     echo "Installing the pulsar charts ..."
     values=${1:-".ci/clusters/values.yaml"}

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -143,6 +143,16 @@ function ci::verify_function_mesh() {
 function ci::verify_hpa() {
     FUNCTION_NAME=$1
     ${KUBECTL} get hpa.v2beta2.autoscaling
+    ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
+    ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
+    WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o -o jsonpath='{.status.conditions}' | grep False | wc -l)
+    while [[ ${WC} -lt 0 ]]; do
+      echo ${WC};
+      sleep 20
+      ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
+      ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
+      WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o -o jsonpath='{.status.conditions}' | grep False | wc -l)
+    done
 }
 
 function ci::test_function_runners() {

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -142,6 +142,8 @@ function ci::verify_function_mesh() {
 
 function ci::verify_hpa() {
     FUNCTION_NAME=$1
+    ${KUBECTL} get function
+    ${KUBECTL} get function ${FUNCTION_NAME} -o yaml
     ${KUBECTL} get hpa.v2beta2.autoscaling
     ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
     ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -69,6 +69,13 @@ function ci::install_metrics_server() {
     ${KUBECTL} apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
     ${KUBECTL} patch deployment metrics-server -n kube-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls","--kubelet-preferred-address-types=InternalIP"]}]}}}}'
     echo "Successfully installed the metrics-server."
+    WC=$(${KUBECTL} get pods -n kube-system --field-selector=status.phase=Running | grep metrics-server | wc -l)
+    while [[ ${WC} -lt 1 ]]; do
+      echo ${WC};
+      sleep 20
+      ${KUBECTL} get pods -n kube-system
+      WC=$(${KUBECTL} get pods -n kube-system --field-selector=status.phase=Running | grep metrics-server | wc -l)
+    done
 }
 
 function ci::install_pulsar_charts() {

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -145,13 +145,14 @@ function ci::verify_hpa() {
     ${KUBECTL} get hpa.v2beta2.autoscaling
     ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
     ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
-    WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o -o jsonpath='{.status.conditions}' | grep False | wc -l)
+    WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}' | grep False | wc -l)
     while [[ ${WC} -lt 0 ]]; do
       echo ${WC};
       sleep 20
       ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
       ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
-      WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o -o jsonpath='{.status.conditions}' | grep False | wc -l)
+      ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}'
+      WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}' | grep False | wc -l)
     done
 }
 

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -145,14 +145,14 @@ function ci::verify_hpa() {
     ${KUBECTL} get hpa.v2beta2.autoscaling
     ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
     ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
-    WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}' | grep False | wc -l)
+    WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[?(@.type=="AbleToScale")].status}' | grep False | wc -l)
     while [[ ${WC} -lt 0 ]]; do
       echo ${WC};
       sleep 20
       ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o yaml
       ${KUBECTL} describe hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function
-      ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}'
-      WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[*].status}' | grep False | wc -l)
+      ${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[?(@.type=="AbleToScale")].status}'
+      WC=$(${KUBECTL} get hpa.v2beta2.autoscaling ${FUNCTION_NAME}-function -o jsonpath='{.status.conditions[?(@.type=="AbleToScale")].status}' | grep False | wc -l)
     done
 }
 

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -126,6 +126,11 @@ function ci::verify_function_mesh() {
     ${KUBECTL} describe pod -lname=${FUNCTION_NAME}
 }
 
+function ci::verify_hpa() {
+    FUNCTION_NAME=$1
+    ${KUBECTL} get hpa.v2beta2.autoscaling
+}
+
 function ci::test_function_runners() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-pulsar-broker-0 -- bin/pulsar-admin functions create --tenant public --namespace default --name test-java --className org.apache.pulsar.functions.api.examples.ExclamationFunction --inputs persistent://public/default/test-java-input --jar /pulsar/examples/api-examples.jar --cpu 0.1
     sleep 15

--- a/.ci/verify_function_mesh.sh
+++ b/.ci/verify_function_mesh.sh
@@ -57,4 +57,12 @@ case ${1} in
     ci::print_function_log functionmesh-sample-python-function
     ci::verify_mesh_function
     ;;
+  compute_v1alpha1_function_hpa)
+    ci::verify_function_mesh function-hpa-sample
+    ci::verify_hpa function-hpa-sample
+    sleep 60
+    ci::print_function_log function-hpa-sample
+    ci::verify_java_function function-hpa-sample
+    ci::verify_hpa function-hpa-sample
+    ;;
 esac

--- a/.ci/verify_function_mesh.sh
+++ b/.ci/verify_function_mesh.sh
@@ -65,4 +65,12 @@ case ${1} in
     ci::verify_java_function function-hpa-sample
     ci::verify_hpa function-hpa-sample
     ;;
+  compute_v1alpha1_function_builtin_hpa)
+    ci::verify_function_mesh function-builtin-hpa-sample
+    ci::verify_hpa function-builtin-hpa-sample
+    sleep 60
+    ci::print_function_log function-builtin-hpa-sample
+    ci::verify_java_function function-builtin-hpa-sample
+    ci::verify_hpa function-builtin-hpa-sample
+    ;;
 esac

--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        run: hack/kind-cluster-build.sh --name chart-testing -c 3 -v 10
         if: steps.list-changed.outputs.changed == 'true'
         with:
           node_image: kindest/node:v1.15.12

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -104,3 +104,13 @@ jobs:
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_function_hpa
           kubectl delete -f .ci/clusters/compute_v1alpha1_function_hpa.yaml
+
+      - name: Test Function Builtin HPA
+        run: |
+          kubectl apply -f .ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+          kubectl get all
+
+      - name: Verify Function Builtin HPA
+        run: |
+          .ci/verify_function_mesh.sh compute_v1alpha1_function_builtin_hpa
+          kubectl delete -f .ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Verify Function kind - Java Function
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_function
+          kubectl delete -f .ci/clusters/compute_v1alpha1_function.yaml
 
       - name: Test Function kind - Python Function
         run: |
@@ -72,6 +73,7 @@ jobs:
       - name: Verify Function kind - Python Function
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_py_function
+          kubectl delete -f .ci/clusters/compute_v1alpha1_py_function.yaml
 
       - name: Test Function kind - Go Function
         run: |
@@ -81,6 +83,7 @@ jobs:
       - name: Verify Function kind - Go Function
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_go_function
+          kubectl delete -f .ci/clusters/compute_v1alpha1_go_function.yaml
 
       - name: Test Mesh kind
         run: |
@@ -90,3 +93,14 @@ jobs:
       - name: Verify Mesh kind
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_functionmesh
+          kubectl delete -f .ci/clusters/compute_v1alpha1_functionmesh.yaml
+
+      - name: Test Function HPA
+        run: |
+          kubectl apply -f .ci/clusters/compute_v1alpha1_function_hpa.yaml
+          kubectl get all
+
+      - name: Verify Function HPA
+        run: |
+          .ci/verify_function_mesh.sh compute_v1alpha1_function_hpa
+          kubectl delete -f .ci/clusters/compute_v1alpha1_function_hpa.yaml

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -96,8 +96,11 @@ type PodPolicy struct {
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// BuiltinAutoscaler refers to the built-in autoscaling rules
+	// Available values: AverageUtilizationCPUPercent80, AverageUtilizationCPUPercent50, AverageUtilizationCPUPercent20
+	// AverageUtilizationMemoryPercent80, AverageUtilizationMemoryPercent50, AverageUtilizationMemoryPercent20
 	// +optional
-	BuiltinAutoscaler BuiltinAutoScaler `json:"builtinAutoscaler,omitempty"`
+	// TODO: validate the rules, user may provide duplicate rules, should check with webhook
+	BuiltinAutoscaler []BuiltinHPARule `json:"builtinAutoscaler,omitempty"`
 
 	// AutoScalingMetrics contains the specifications for which to use to calculate the
 	// desired replica count (the maximum replica count across all metrics will

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -20,6 +20,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,6 +94,13 @@ type PodPolicy struct {
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// HPAutoscaler allows user to configure the HPA with k8s.io/api/autoscaling/v2beta2
+	// This config will override the maxReplicas in Function/Source/Sink Spec
+	// If user set HPAutoscaler, then controller will use HPAutoscaler to create HPA
+	// More info: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+	// +optional
+	HPAutoscaler *autov2beta2.HorizontalPodAutoscalerSpec `json:"hpAutoscaler,omitempty"`
 }
 
 type Runtime struct {

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -95,6 +95,10 @@ type PodPolicy struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
+	// BuiltinAutoscaler refers to the built-in autoscaling rules
+	// +optional
+	BuiltinAutoscaler BuiltinAutoScaler `json:"builtinAutoscaler,omitempty"`
+
 	// AutoScalingMetrics contains the specifications for which to use to calculate the
 	// desired replica count (the maximum replica count across all metrics will
 	// be used).

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -95,12 +95,18 @@ type PodPolicy struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// HPAutoscaler allows user to configure the HPA with k8s.io/api/autoscaling/v2beta2
-	// This config will override the maxReplicas in Function/Source/Sink Spec
-	// If user set HPAutoscaler, then controller will use HPAutoscaler to create HPA
-	// More info: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+	// AutoScalingMetrics contains the specifications for which to use to calculate the
+	// desired replica count (the maximum replica count across all metrics will
+	// be used).
+	// More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling
 	// +optional
-	HPAutoscaler *autov2beta2.HorizontalPodAutoscalerSpec `json:"hpAutoscaler,omitempty"`
+	AutoScalingMetrics []autov2beta2.MetricSpec `json:"autoScalingMetrics,omitempty"`
+
+	// AutoScalingBehavior configures the scaling behavior of the target
+	// in both Up and Down directions (scaleUp and scaleDown fields respectively).
+	// If not set, the default HPAScalingRules for scale up and scale down are used.
+	// +optional
+	AutoScalingBehavior *autov2beta2.HorizontalPodAutoscalerBehavior `json:"autoScalingBehavior,omitempty"`
 }
 
 type Runtime struct {

--- a/api/v1alpha1/function_types.go
+++ b/api/v1alpha1/function_types.go
@@ -29,11 +29,15 @@ import (
 type FunctionSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Name        string     `json:"name,omitempty"`
-	ClassName   string     `json:"className,omitempty"`
-	Tenant      string     `json:"tenant,omitempty"`
-	ClusterName string     `json:"clusterName,omitempty"`
-	Replicas    *int32     `json:"replicas,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ClassName   string `json:"className,omitempty"`
+	Tenant      string `json:"tenant,omitempty"`
+	ClusterName string `json:"clusterName,omitempty"`
+	Replicas    *int32 `json:"replicas,omitempty"`
+
+	// MaxReplicas indicates the maximum number of replicas and enables the HorizontalPodAutoscaler
+	// If provided, a default HPA with CPU at average of 80% will be used.
+	// For complex HPA strategies, please refer to Pod.HPAutoscaler.
 	MaxReplicas *int32     `json:"maxReplicas,omitempty"` // if provided, turn on autoscaling
 	Input       InputConf  `json:"input,omitempty"`
 	Output      OutputConf `json:"output,omitempty"`

--- a/api/v1alpha1/hpa.go
+++ b/api/v1alpha1/hpa.go
@@ -1,10 +1,13 @@
 package v1alpha1
 
-type BuiltinAutoScaler struct {
-	Type string `json:"type,omitempty"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:pruning:PreserveUnknownFields
-	Config *Config `json:"config,omitempty"`
-}
+type BuiltinHPARule string
 
-type
+const (
+	AverageUtilizationCPUPercent80 BuiltinHPARule = "AverageUtilizationCPUPercent80"
+	AverageUtilizationCPUPercent50 BuiltinHPARule = "AverageUtilizationCPUPercent50"
+	AverageUtilizationCPUPercent20 BuiltinHPARule = "AverageUtilizationCPUPercent20"
+
+	AverageUtilizationMemoryPercent80 BuiltinHPARule = "AverageUtilizationMemoryPercent80"
+	AverageUtilizationMemoryPercent50 BuiltinHPARule = "AverageUtilizationMemoryPercent50"
+	AverageUtilizationMemoryPercent20 BuiltinHPARule = "AverageUtilizationMemoryPercent20"
+)

--- a/api/v1alpha1/hpa.go
+++ b/api/v1alpha1/hpa.go
@@ -1,0 +1,10 @@
+package v1alpha1
+
+type BuiltinAutoScaler struct {
+	Type string `json:"type,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Config *Config `json:"config,omitempty"`
+}
+
+type

--- a/api/v1alpha1/hpa.go
+++ b/api/v1alpha1/hpa.go
@@ -1,3 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package v1alpha1 contains API Schema definitions for the cloud v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=compute.functionmesh.io
 package v1alpha1
 
 type BuiltinHPARule string

--- a/api/v1alpha1/sink_types.go
+++ b/api/v1alpha1/sink_types.go
@@ -29,12 +29,16 @@ import (
 type SinkSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Name        string    `json:"name,omitempty"`
-	ClassName   string    `json:"className,omitempty"`
-	ClusterName string    `json:"clusterName,omitempty"`
-	Tenant      string    `json:"tenant,omitempty"`
-	SinkType    string    `json:"sinkType,omitempty"` // refer to `--sink-type` as builtin connector
-	Replicas    *int32    `json:"replicas,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ClassName   string `json:"className,omitempty"`
+	ClusterName string `json:"clusterName,omitempty"`
+	Tenant      string `json:"tenant,omitempty"`
+	SinkType    string `json:"sinkType,omitempty"` // refer to `--sink-type` as builtin connector
+	Replicas    *int32 `json:"replicas,omitempty"`
+
+	// MaxReplicas indicates the maximum number of replicas and enables the HorizontalPodAutoscaler
+	// If provided, a default HPA with CPU at average of 80% will be used.
+	// For complex HPA strategies, please refer to Pod.HPAutoscaler.
 	MaxReplicas *int32    `json:"maxReplicas,omitempty"` // if provided, turn on autoscaling
 	Input       InputConf `json:"input,omitempty"`
 

--- a/api/v1alpha1/source_types.go
+++ b/api/v1alpha1/source_types.go
@@ -29,12 +29,16 @@ import (
 type SourceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Name        string     `json:"name,omitempty"`
-	ClassName   string     `json:"className,omitempty"`
-	Tenant      string     `json:"tenant,omitempty"`
-	ClusterName string     `json:"clusterName,omitempty"`
-	SourceType  string     `json:"sourceType,omitempty"` // refer to `--source-type` as builtin connector
-	Replicas    *int32     `json:"replicas,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ClassName   string `json:"className,omitempty"`
+	Tenant      string `json:"tenant,omitempty"`
+	ClusterName string `json:"clusterName,omitempty"`
+	SourceType  string `json:"sourceType,omitempty"` // refer to `--source-type` as builtin connector
+	Replicas    *int32 `json:"replicas,omitempty"`
+
+	// MaxReplicas indicates the maximum number of replicas and enables the HorizontalPodAutoscaler
+	// If provided, a default HPA with CPU at average of 80% will be used.
+	// For complex HPA strategies, please refer to Pod.HPAutoscaler.
 	MaxReplicas *int32     `json:"maxReplicas,omitempty"` // if provided, turn on autoscaling
 	Output      OutputConf `json:"output,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -583,9 +583,16 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.HPAutoscaler != nil {
-		in, out := &in.HPAutoscaler, &out.HPAutoscaler
-		*out = new(v2beta2.HorizontalPodAutoscalerSpec)
+	if in.AutoScalingMetrics != nil {
+		in, out := &in.AutoScalingMetrics, &out.AutoScalingMetrics
+		*out = make([]v2beta2.MetricSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.AutoScalingBehavior != nil {
+		in, out := &in.AutoScalingBehavior, &out.AutoScalingBehavior
+		*out = new(v2beta2.HorizontalPodAutoscalerBehavior)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -583,6 +583,11 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.BuiltinAutoscaler != nil {
+		in, out := &in.BuiltinAutoscaler, &out.BuiltinAutoscaler
+		*out = make([]BuiltinHPARule, len(*in))
+		copy(*out, *in)
+	}
 	if in.AutoScalingMetrics != nil {
 		in, out := &in.AutoScalingMetrics, &out.AutoScalingMetrics
 		*out = make([]v2beta2.MetricSpec, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -581,6 +582,11 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.HPAutoscaler != nil {
+		in, out := &in.HPAutoscaler, &out.HPAutoscaler
+		*out = new(v2beta2.HorizontalPodAutoscalerSpec)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_functionmeshes.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_functionmeshes.yaml
@@ -478,6 +478,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      autoScalingBehavior:
+                        properties:
+                          scaleDown:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -2372,8 +2619,6 @@ spec:
                       jarLocation:
                         type: string
                     type: object
-                  logTopic:
-                    type: string
                   maxMessageRetry:
                     format: int32
                     type: integer
@@ -2653,6 +2898,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      autoScalingBehavior:
+                        properties:
+                          scaleDown:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -4472,8 +4964,6 @@ spec:
                       jarLocation:
                         type: string
                     type: object
-                  logTopic:
-                    type: string
                   maxReplicas:
                     format: int32
                     type: integer
@@ -4806,6 +5296,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      autoScalingBehavior:
+                        properties:
+                          scaleDown:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_functions.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_functions.yaml
@@ -479,6 +479,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                autoScalingBehavior:
+                  properties:
+                    scaleDown:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_sinks.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_sinks.yaml
@@ -134,8 +134,6 @@ spec:
                 jarLocation:
                   type: string
               type: object
-            logTopic:
-              type: string
             maxMessageRetry:
               format: int32
               type: integer
@@ -415,6 +413,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                autoScalingBehavior:
+                  properties:
+                    scaleDown:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_sources.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_sources.yaml
@@ -56,8 +56,6 @@ spec:
                 jarLocation:
                   type: string
               type: object
-            logTopic:
-              type: string
             maxReplicas:
               format: int32
               type: integer
@@ -390,6 +388,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                autoScalingBehavior:
+                  properties:
+                    scaleDown:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
@@ -478,277 +478,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -2922,277 +2898,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -5346,277 +5298,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:

--- a/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
@@ -478,6 +478,277 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
+                        type: object
                       imagePullSecrets:
                         items:
                           properties:
@@ -2651,6 +2922,277 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
+                        type: object
                       imagePullSecrets:
                         items:
                           properties:
@@ -4803,6 +5345,277 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
                         type: object
                       imagePullSecrets:
                         items:

--- a/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
@@ -725,6 +725,10 @@ spec:
                           - type
                           type: object
                         type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -3145,6 +3149,10 @@ spec:
                           - type
                           type: object
                         type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -5544,6 +5552,10 @@ spec:
                           required:
                           - type
                           type: object
+                        type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
                         type: array
                       imagePullSecrets:
                         items:

--- a/config/crd/bases/compute.functionmesh.io_functions.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functions.yaml
@@ -726,6 +726,10 @@ spec:
                     - type
                     type: object
                   type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_functions.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functions.yaml
@@ -479,6 +479,277 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
+                  type: object
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_functions.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functions.yaml
@@ -479,277 +479,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sinks.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sinks.yaml
@@ -413,277 +413,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sinks.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sinks.yaml
@@ -413,6 +413,277 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
+                  type: object
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sinks.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sinks.yaml
@@ -660,6 +660,10 @@ spec:
                     - type
                     type: object
                   type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sources.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sources.yaml
@@ -390,6 +390,277 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
+                  type: object
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sources.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sources.yaml
@@ -637,6 +637,10 @@ spec:
                     - type
                     type: object
                   type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/config/crd/bases/compute.functionmesh.io_sources.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sources.yaml
@@ -390,277 +390,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -219,7 +219,6 @@ func (r *FunctionReconciler) ApplyFunctionHPA(ctx context.Context, req ctrl.Requ
 	switch condition.Action {
 	case v1alpha1.Create:
 		hpa := spec.MakeFunctionHPA(function)
-		r.Log.Info("hpa", "hpa", *hpa)
 		if err := r.Create(ctx, hpa); err != nil {
 			r.Log.Error(err, "failed to create pod autoscaler for function", "name", function.Name)
 			return err

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -23,7 +23,7 @@ import (
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/spec"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,7 +186,7 @@ func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Re
 		return nil
 	}
 
-	hpa := &autov1.HorizontalPodAutoscaler{}
+	hpa := &autov2beta2.HorizontalPodAutoscaler{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: function.Namespace,
 		Name: spec.MakeFunctionObjectMeta(function).Name}, hpa)
 	if err != nil {

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -167,7 +167,7 @@ func (r *FunctionReconciler) ApplyFunctionService(ctx context.Context, req ctrl.
 
 func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if function.Spec.MaxReplicas == nil {
+	if function.Spec.Pod.HPAutoscaler == nil && function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -205,7 +205,7 @@ func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Re
 
 func (r *FunctionReconciler) ApplyFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if function.Spec.MaxReplicas == nil {
+	if function.Spec.Pod.HPAutoscaler == nil && function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"reflect"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/streamnative/function-mesh/api/v1alpha1"

--- a/controllers/function.go
+++ b/controllers/function.go
@@ -167,7 +167,7 @@ func (r *FunctionReconciler) ApplyFunctionService(ctx context.Context, req ctrl.
 
 func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if function.Spec.Pod.HPAutoscaler == nil && function.Spec.MaxReplicas == nil {
+	if function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -205,7 +205,7 @@ func (r *FunctionReconciler) ObserveFunctionHPA(ctx context.Context, req ctrl.Re
 
 func (r *FunctionReconciler) ApplyFunctionHPA(ctx context.Context, req ctrl.Request,
 	function *v1alpha1.Function) error {
-	if function.Spec.Pod.HPAutoscaler == nil && function.Spec.MaxReplicas == nil {
+	if function.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -219,6 +219,7 @@ func (r *FunctionReconciler) ApplyFunctionHPA(ctx context.Context, req ctrl.Requ
 	switch condition.Action {
 	case v1alpha1.Create:
 		hpa := spec.MakeFunctionHPA(function)
+		r.Log.Info("hpa", "hpa", *hpa)
 		if err := r.Create(ctx, hpa); err != nil {
 			r.Log.Error(err, "failed to create pod autoscaler for function", "name", function.Name)
 			return err

--- a/controllers/function_controller.go
+++ b/controllers/function_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,7 +106,7 @@ func (r *FunctionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.Function{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Owns(&autov1.HorizontalPodAutoscaler{}).
+		Owns(&autov2beta2.HorizontalPodAutoscaler{}).
 		Owns(&corev1.Secret{}).
 		Complete(r)
 }

--- a/controllers/function_controller_test.go
+++ b/controllers/function_controller_test.go
@@ -97,10 +97,7 @@ func createFunction(function *v1alpha1.Function) {
 				Namespace: function.Namespace,
 				Name:      spec.MakeFunctionObjectMeta(function).Name,
 			}, statefulSet)
-			if err != nil {
-				return false
-			}
-			return true
+			return err == nil
 		}, timeout, interval).Should(BeTrue())
 
 		Expect(*statefulSet.Spec.Replicas).Should(Equal(int32(1)))
@@ -112,10 +109,7 @@ func createFunction(function *v1alpha1.Function) {
 		Eventually(func() bool {
 			err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: function.Namespace,
 				Name: svcName}, srv)
-			if err != nil {
-				return false
-			}
-			return true
+			return err == nil
 		}, timeout, interval).Should(BeTrue())
 	})
 
@@ -125,10 +119,7 @@ func createFunction(function *v1alpha1.Function) {
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: function.Namespace,
 					Name: spec.MakeFunctionObjectMeta(function).Name}, hpa)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 		}
 	})

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -155,7 +155,7 @@ func (r *SinkReconciler) ApplySinkService(ctx context.Context, req ctrl.Request,
 }
 
 func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if sink.Spec.Pod.HPAutoscaler == nil && sink.Spec.MaxReplicas == nil {
+	if sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -187,7 +187,7 @@ func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, s
 }
 
 func (r *SinkReconciler) ApplySinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if sink.Spec.Pod.HPAutoscaler == nil && sink.Spec.MaxReplicas == nil {
+	if sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -228,11 +228,17 @@ func (r *SinkReconciler) ApplySinkHPA(ctx context.Context, req ctrl.Request, sin
 		if hpa.Spec.MaxReplicas != *sink.Spec.MaxReplicas {
 			hpa.Spec.MaxReplicas = *sink.Spec.MaxReplicas
 		}
-		if !reflect.DeepEqual(hpa.Spec.Metrics, sink.Spec.Pod.AutoScalingMetrics) {
+		if len(sink.Spec.Pod.AutoScalingMetrics) > 0 && !reflect.DeepEqual(hpa.Spec.Metrics, sink.Spec.Pod.AutoScalingMetrics) {
 			hpa.Spec.Metrics = sink.Spec.Pod.AutoScalingMetrics
 		}
 		if sink.Spec.Pod.AutoScalingBehavior != nil {
 			hpa.Spec.Behavior = sink.Spec.Pod.AutoScalingBehavior
+		}
+		if len(sink.Spec.Pod.BuiltinAutoscaler) > 0 {
+			metrics := spec.MakeMetricsFromBuiltinHPARules(sink.Spec.Pod.BuiltinAutoscaler)
+			if !reflect.DeepEqual(hpa.Spec.Metrics, metrics) {
+				hpa.Spec.Metrics = metrics
+			}
 		}
 		if err := r.Update(ctx, hpa); err != nil {
 			r.Log.Error(err, "failed to update pod autoscaler for sink", "name", sink.Name)

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -23,7 +23,7 @@ import (
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/spec"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,7 +166,7 @@ func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, s
 		Action:    v1alpha1.NoAction,
 	}
 
-	hpa := &autov1.HorizontalPodAutoscaler{}
+	hpa := &autov2beta2.HorizontalPodAutoscaler{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: sink.Namespace,
 		Name: spec.MakeSinkObjectMeta(sink).Name}, hpa)
 	if err != nil {

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -155,7 +155,7 @@ func (r *SinkReconciler) ApplySinkService(ctx context.Context, req ctrl.Request,
 }
 
 func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if sink.Spec.MaxReplicas == nil {
+	if sink.Spec.Pod.HPAutoscaler == nil && sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -187,7 +187,7 @@ func (r *SinkReconciler) ObserveSinkHPA(ctx context.Context, req ctrl.Request, s
 }
 
 func (r *SinkReconciler) ApplySinkHPA(ctx context.Context, req ctrl.Request, sink *v1alpha1.Sink) error {
-	if sink.Spec.MaxReplicas == nil {
+	if sink.Spec.Pod.HPAutoscaler == nil && sink.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/sink_controller.go
+++ b/controllers/sink_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	computev1alpha1 "github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,6 +104,6 @@ func (r *SinkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&computev1alpha1.Sink{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Owns(&autov1.HorizontalPodAutoscaler{}).
+		Owns(&autov2beta2.HorizontalPodAutoscaler{}).
 		Complete(r)
 }

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -157,7 +157,7 @@ func (r *SourceReconciler) ApplySourceService(ctx context.Context, req ctrl.Requ
 }
 
 func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if source.Spec.MaxReplicas == nil {
+	if source.Spec.Pod.HPAutoscaler == nil && source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -189,7 +189,7 @@ func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Reques
 }
 
 func (r *SourceReconciler) ApplySourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if source.Spec.MaxReplicas == nil {
+	if source.Spec.Pod.HPAutoscaler == nil && source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -23,7 +23,7 @@ import (
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/spec"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,7 +168,7 @@ func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Reques
 		Action:    v1alpha1.NoAction,
 	}
 
-	hpa := &autov1.HorizontalPodAutoscaler{}
+	hpa := &autov2beta2.HorizontalPodAutoscaler{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: source.Namespace,
 		Name: spec.MakeSourceObjectMeta(source).Name}, hpa)
 	if err != nil {

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -157,7 +157,7 @@ func (r *SourceReconciler) ApplySourceService(ctx context.Context, req ctrl.Requ
 }
 
 func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if source.Spec.Pod.HPAutoscaler == nil && source.Spec.MaxReplicas == nil {
+	if source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}
@@ -189,7 +189,7 @@ func (r *SourceReconciler) ObserveSourceHPA(ctx context.Context, req ctrl.Reques
 }
 
 func (r *SourceReconciler) ApplySourceHPA(ctx context.Context, req ctrl.Request, source *v1alpha1.Source) error {
-	if source.Spec.Pod.HPAutoscaler == nil && source.Spec.MaxReplicas == nil {
+	if source.Spec.MaxReplicas == nil {
 		// HPA not enabled, skip further action
 		return nil
 	}

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -230,11 +230,17 @@ func (r *SourceReconciler) ApplySourceHPA(ctx context.Context, req ctrl.Request,
 		if hpa.Spec.MaxReplicas != *source.Spec.MaxReplicas {
 			hpa.Spec.MaxReplicas = *source.Spec.MaxReplicas
 		}
-		if !reflect.DeepEqual(hpa.Spec.Metrics, source.Spec.Pod.AutoScalingMetrics) {
+		if len(source.Spec.Pod.AutoScalingMetrics) > 0 && !reflect.DeepEqual(hpa.Spec.Metrics, source.Spec.Pod.AutoScalingMetrics) {
 			hpa.Spec.Metrics = source.Spec.Pod.AutoScalingMetrics
 		}
 		if source.Spec.Pod.AutoScalingBehavior != nil {
 			hpa.Spec.Behavior = source.Spec.Pod.AutoScalingBehavior
+		}
+		if len(source.Spec.Pod.BuiltinAutoscaler) > 0 {
+			metrics := spec.MakeMetricsFromBuiltinHPARules(source.Spec.Pod.BuiltinAutoscaler)
+			if !reflect.DeepEqual(hpa.Spec.Metrics, metrics) {
+				hpa.Spec.Metrics = metrics
+			}
 		}
 		if err := r.Update(ctx, hpa); err != nil {
 			r.Log.Error(err, "failed to update pod autoscaler for source", "name", source.Name)

--- a/controllers/source_controller.go
+++ b/controllers/source_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	computev1alpha1 "github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,6 +104,6 @@ func (r *SourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&computev1alpha1.Source{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Owns(&autov1.HorizontalPodAutoscaler{}).
+		Owns(&autov2beta2.HorizontalPodAutoscaler{}).
 		Complete(r)
 }

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"time"
 
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
+
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/proto"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -97,24 +98,35 @@ func MakeHeadlessServiceName(serviceName string) string {
 }
 
 func MakeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
-	kind string) *autov1.HorizontalPodAutoscaler {
+	kind string) *autov2beta2.HorizontalPodAutoscaler {
 	// TODO: configurable cpu percentage
 	cpuPercentage := int32(80)
-	return &autov1.HorizontalPodAutoscaler{
+	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "autoscaling/v1",
 			APIVersion: "HorizontalPodAutoscaler",
 		},
 		ObjectMeta: *objectMeta,
-		Spec: autov1.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autov1.CrossVersionObjectReference{
+		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
 				Kind:       kind,
 				Name:       objectMeta.Name,
 				APIVersion: "compute.functionmesh.io/v1alpha1",
 			},
-			MinReplicas:                    &minReplicas,
-			MaxReplicas:                    maxReplicas,
-			TargetCPUUtilizationPercentage: &cpuPercentage,
+			MinReplicas: &minReplicas,
+			MaxReplicas: maxReplicas,
+			Metrics: []autov2beta2.MetricSpec{
+				{
+					Type: autov2beta2.ResourceMetricSourceType,
+					Resource: &autov2beta2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autov2beta2.MetricTarget{
+							Type:               autov2beta2.UtilizationMetricType,
+							AverageUtilization: &cpuPercentage,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -97,7 +97,7 @@ func MakeHeadlessServiceName(serviceName string) string {
 	return fmt.Sprintf("%s-headless", serviceName)
 }
 
-func MakeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
+func MakeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
 	kind string) *autov2beta2.HorizontalPodAutoscaler {
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
@@ -114,6 +114,28 @@ func MakeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxReplicas,
 			Metrics:     defaultHPAMetrics(),
+		},
+	}
+}
+
+func MakeHPA(objectMeta *metav1.ObjectMeta, autoscalerSpec *autov2beta2.HorizontalPodAutoscalerSpec,
+	kind string) *autov2beta2.HorizontalPodAutoscaler {
+	return &autov2beta2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "autoscaling/v1",
+			APIVersion: "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: *objectMeta,
+		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
+				Kind:       kind,
+				Name:       objectMeta.Name,
+				APIVersion: "compute.functionmesh.io/v1alpha1",
+			},
+			MinReplicas: autoscalerSpec.MinReplicas,
+			MaxReplicas: autoscalerSpec.MaxReplicas,
+			Metrics:     autoscalerSpec.Metrics,
+			Behavior:    autoscalerSpec.Behavior,
 		},
 	}
 }

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -99,8 +99,6 @@ func MakeHeadlessServiceName(serviceName string) string {
 
 func MakeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
 	kind string) *autov2beta2.HorizontalPodAutoscaler {
-	// TODO: configurable cpu percentage
-	cpuPercentage := int32(80)
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "autoscaling/v1",
@@ -115,18 +113,7 @@ func MakeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
 			},
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxReplicas,
-			Metrics: []autov2beta2.MetricSpec{
-				{
-					Type: autov2beta2.ResourceMetricSourceType,
-					Resource: &autov2beta2.ResourceMetricSource{
-						Name: corev1.ResourceCPU,
-						Target: autov2beta2.MetricTarget{
-							Type:               autov2beta2.UtilizationMetricType,
-							AverageUtilization: &cpuPercentage,
-						},
-					},
-				},
-			},
+			Metrics:     defaultHPAMetrics(),
 		},
 	}
 }

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
-
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/proto"
 
@@ -95,49 +93,6 @@ func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev
 // MakeHeadlessServiceName changes the name of service to headless style
 func MakeHeadlessServiceName(serviceName string) string {
 	return fmt.Sprintf("%s-headless", serviceName)
-}
-
-func MakeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
-	kind string) *autov2beta2.HorizontalPodAutoscaler {
-	return &autov2beta2.HorizontalPodAutoscaler{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "autoscaling/v1",
-			APIVersion: "HorizontalPodAutoscaler",
-		},
-		ObjectMeta: *objectMeta,
-		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
-				Kind:       kind,
-				Name:       objectMeta.Name,
-				APIVersion: "compute.functionmesh.io/v1alpha1",
-			},
-			MinReplicas: &minReplicas,
-			MaxReplicas: maxReplicas,
-			Metrics:     defaultHPAMetrics(),
-		},
-	}
-}
-
-func MakeHPA(objectMeta *metav1.ObjectMeta, autoscalerSpec *autov2beta2.HorizontalPodAutoscalerSpec,
-	kind string) *autov2beta2.HorizontalPodAutoscaler {
-	return &autov2beta2.HorizontalPodAutoscaler{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "autoscaling/v1",
-			APIVersion: "HorizontalPodAutoscaler",
-		},
-		ObjectMeta: *objectMeta,
-		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
-				Kind:       kind,
-				Name:       objectMeta.Name,
-				APIVersion: "compute.functionmesh.io/v1alpha1",
-			},
-			MinReplicas: autoscalerSpec.MinReplicas,
-			MaxReplicas: autoscalerSpec.MaxReplicas,
-			Metrics:     autoscalerSpec.Metrics,
-			Behavior:    autoscalerSpec.Behavior,
-		},
-	}
 }
 
 func MakeStatefulSet(objectMeta *metav1.ObjectMeta, replicas *int32, container *corev1.Container,

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -28,14 +28,19 @@ import (
 )
 
 // log is for logging in this package.
-var log = logf.Log.WithName("sink-resource")
+var log = logf.Log.WithName("function-resource")
 
 func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeFunctionObjectMeta(function)
-	if !isDefaultHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
-		return makeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Spec.Pod)
+	targetRef := autov2beta2.CrossVersionObjectReference{
+		Kind:       function.Kind,
+		Name:       function.Name,
+		APIVersion: function.APIVersion,
 	}
-	return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas)
+	if !isDefaultHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
+		return makeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Spec.Pod, targetRef)
+	}
+	return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, targetRef)
 }
 
 func MakeFunctionService(function *v1alpha1.Function) *corev1.Service {

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -37,7 +37,9 @@ func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAuto
 		Name:       function.Name,
 		APIVersion: function.APIVersion,
 	}
-	if !isDefaultHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
+	if isBuiltinHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
+		return makeBuiltinHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, targetRef, function.Spec.Pod.BuiltinAutoscaler)
+	} else if !isDefaultHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
 		return makeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Spec.Pod, targetRef)
 	}
 	return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, targetRef)

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -32,7 +32,11 @@ var log = logf.Log.WithName("sink-resource")
 
 func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeFunctionObjectMeta(function)
-	return MakeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
+	if function.Spec.Pod.HPAutoscaler == nil {
+		return MakeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
+	} else {
+		return MakeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
+	}
 }
 
 func MakeFunctionService(function *v1alpha1.Function) *corev1.Service {

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -34,9 +34,8 @@ func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAuto
 	objectMeta := MakeFunctionObjectMeta(function)
 	if function.Spec.Pod.HPAutoscaler == nil {
 		return MakeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
-	} else {
-		return MakeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
 	}
+	return MakeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
 }
 
 func MakeFunctionService(function *v1alpha1.Function) *corev1.Service {

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -32,10 +32,10 @@ var log = logf.Log.WithName("sink-resource")
 
 func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeFunctionObjectMeta(function)
-	if function.Spec.Pod.HPAutoscaler == nil {
-		return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
+	if !isDefaultHPAEnabled(function.Spec.Replicas, function.Spec.MaxReplicas, function.Spec.Pod) {
+		return makeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Spec.Pod)
 	}
-	return makeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
+	return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas)
 }
 
 func MakeFunctionService(function *v1alpha1.Function) *corev1.Service {

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,7 +30,7 @@ import (
 // log is for logging in this package.
 var log = logf.Log.WithName("sink-resource")
 
-func MakeFunctionHPA(function *v1alpha1.Function) *autov1.HorizontalPodAutoscaler {
+func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeFunctionObjectMeta(function)
 	return MakeHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
 }

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -33,9 +33,9 @@ var log = logf.Log.WithName("sink-resource")
 func MakeFunctionHPA(function *v1alpha1.Function) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeFunctionObjectMeta(function)
 	if function.Spec.Pod.HPAutoscaler == nil {
-		return MakeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
+		return makeDefaultHPA(objectMeta, *function.Spec.Replicas, *function.Spec.MaxReplicas, function.Kind)
 	}
-	return MakeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
+	return makeHPA(objectMeta, function.Spec.Pod.HPAutoscaler, function.Kind)
 }
 
 func MakeFunctionService(function *v1alpha1.Function) *corev1.Service {

--- a/controllers/spec/hpa.go
+++ b/controllers/spec/hpa.go
@@ -46,7 +46,7 @@ func defaultHPAMetrics() []autov2beta2.MetricSpec {
 	}
 }
 
-func makeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32) *autov2beta2.HorizontalPodAutoscaler {
+func makeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32, targetRef autov2beta2.CrossVersionObjectReference) *autov2beta2.HorizontalPodAutoscaler {
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "autoscaling/v2beta2",
@@ -54,29 +54,21 @@ func makeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int3
 		},
 		ObjectMeta: *objectMeta,
 		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
-				Kind:       "StatefulSet",
-				Name:       objectMeta.Name,
-				APIVersion: "apps/v1",
-			},
-			MinReplicas: &minReplicas,
-			MaxReplicas: maxReplicas,
-			Metrics:     defaultHPAMetrics(),
+			ScaleTargetRef: targetRef,
+			MinReplicas:    &minReplicas,
+			MaxReplicas:    maxReplicas,
+			Metrics:        defaultHPAMetrics(),
 		},
 	}
 }
 
-func makeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32, podPolicy v1alpha1.PodPolicy) *autov2beta2.HorizontalPodAutoscaler {
+func makeHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32, podPolicy v1alpha1.PodPolicy, targetRef autov2beta2.CrossVersionObjectReference) *autov2beta2.HorizontalPodAutoscaler {
 	spec := autov2beta2.HorizontalPodAutoscalerSpec{
-		ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
-			Kind:       "StatefulSet",
-			Name:       objectMeta.Name,
-			APIVersion: "apps/v1",
-		},
-		MinReplicas: &minReplicas,
-		MaxReplicas: maxReplicas,
-		Metrics:     podPolicy.AutoScalingMetrics,
-		Behavior:    podPolicy.AutoScalingBehavior,
+		ScaleTargetRef: targetRef,
+		MinReplicas:    &minReplicas,
+		MaxReplicas:    maxReplicas,
+		Metrics:        podPolicy.AutoScalingMetrics,
+		Behavior:       podPolicy.AutoScalingBehavior,
 	}
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/spec/hpa.go
+++ b/controllers/spec/hpa.go
@@ -41,7 +41,7 @@ func defaultHPAMetrics() []autov2beta2.MetricSpec {
 	}
 }
 
-func MakeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
+func makeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
 	kind string) *autov2beta2.HorizontalPodAutoscaler {
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
@@ -62,24 +62,20 @@ func MakeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int3
 	}
 }
 
-func MakeHPA(objectMeta *metav1.ObjectMeta, autoscalerSpec *autov2beta2.HorizontalPodAutoscalerSpec,
+func makeHPA(objectMeta *metav1.ObjectMeta, autoscalerSpec *autov2beta2.HorizontalPodAutoscalerSpec,
 	kind string) *autov2beta2.HorizontalPodAutoscaler {
+	spec := *autoscalerSpec
+	spec.ScaleTargetRef = autov2beta2.CrossVersionObjectReference{
+		Kind:       kind,
+		Name:       objectMeta.Name,
+		APIVersion: "compute.functionmesh.io/v1alpha1",
+	}
 	return &autov2beta2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "autoscaling/v1",
 			APIVersion: "HorizontalPodAutoscaler",
 		},
 		ObjectMeta: *objectMeta,
-		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
-				Kind:       kind,
-				Name:       objectMeta.Name,
-				APIVersion: "compute.functionmesh.io/v1alpha1",
-			},
-			MinReplicas: autoscalerSpec.MinReplicas,
-			MaxReplicas: autoscalerSpec.MaxReplicas,
-			Metrics:     autoscalerSpec.Metrics,
-			Behavior:    autoscalerSpec.Behavior,
-		},
+		Spec:       spec,
 	}
 }

--- a/controllers/spec/hpa.go
+++ b/controllers/spec/hpa.go
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+import (
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// defaultHPAMetrics generates a default HPA metrics settings based on CPU usage and utilized on 80%.
+func defaultHPAMetrics() []autov2beta2.MetricSpec {
+	// TODO: configurable cpu percentage
+	cpuPercentage := int32(80)
+	return []autov2beta2.MetricSpec{
+		{
+			Type: autov2beta2.ResourceMetricSourceType,
+			Resource: &autov2beta2.ResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autov2beta2.MetricTarget{
+					Type:               autov2beta2.UtilizationMetricType,
+					AverageUtilization: &cpuPercentage,
+				},
+			},
+		},
+	}
+}

--- a/controllers/spec/hpa.go
+++ b/controllers/spec/hpa.go
@@ -20,6 +20,7 @@ package spec
 import (
 	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // defaultHPAMetrics generates a default HPA metrics settings based on CPU usage and utilized on 80%.
@@ -36,6 +37,49 @@ func defaultHPAMetrics() []autov2beta2.MetricSpec {
 					AverageUtilization: &cpuPercentage,
 				},
 			},
+		},
+	}
+}
+
+func MakeDefaultHPA(objectMeta *metav1.ObjectMeta, minReplicas, maxReplicas int32,
+	kind string) *autov2beta2.HorizontalPodAutoscaler {
+	return &autov2beta2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "autoscaling/v1",
+			APIVersion: "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: *objectMeta,
+		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
+				Kind:       kind,
+				Name:       objectMeta.Name,
+				APIVersion: "compute.functionmesh.io/v1alpha1",
+			},
+			MinReplicas: &minReplicas,
+			MaxReplicas: maxReplicas,
+			Metrics:     defaultHPAMetrics(),
+		},
+	}
+}
+
+func MakeHPA(objectMeta *metav1.ObjectMeta, autoscalerSpec *autov2beta2.HorizontalPodAutoscalerSpec,
+	kind string) *autov2beta2.HorizontalPodAutoscaler {
+	return &autov2beta2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "autoscaling/v1",
+			APIVersion: "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: *objectMeta,
+		Spec: autov2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autov2beta2.CrossVersionObjectReference{
+				Kind:       kind,
+				Name:       objectMeta.Name,
+				APIVersion: "compute.functionmesh.io/v1alpha1",
+			},
+			MinReplicas: autoscalerSpec.MinReplicas,
+			MaxReplicas: autoscalerSpec.MaxReplicas,
+			Metrics:     autoscalerSpec.Metrics,
+			Behavior:    autoscalerSpec.Behavior,
 		},
 	}
 }

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -28,7 +28,11 @@ import (
 
 func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
-	return MakeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
+	if sink.Spec.Pod.HPAutoscaler == nil {
+		return MakeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
+	} else {
+		return MakeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
+	}
 }
 
 func MakeSinkService(sink *v1alpha1.Sink) *corev1.Service {

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -29,9 +29,9 @@ import (
 func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
 	if sink.Spec.Pod.HPAutoscaler == nil {
-		return MakeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
+		return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
 	}
-	return MakeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
+	return makeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
 }
 
 func MakeSinkService(sink *v1alpha1.Sink) *corev1.Service {

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -33,7 +33,9 @@ func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 		Name:       sink.Name,
 		APIVersion: sink.APIVersion,
 	}
-	if !isDefaultHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
+	if isBuiltinHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
+		return makeBuiltinHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, targetRef, sink.Spec.Pod.BuiltinAutoscaler)
+	} else if !isDefaultHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
 		return makeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Spec.Pod, targetRef)
 	}
 	return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, targetRef)

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -21,12 +21,12 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func MakeSinkHPA(sink *v1alpha1.Sink) *autov1.HorizontalPodAutoscaler {
+func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
 	return MakeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
 }

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -28,10 +28,10 @@ import (
 
 func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
-	if sink.Spec.Pod.HPAutoscaler == nil {
-		return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
+	if !isDefaultHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
+		return makeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Spec.Pod)
 	}
-	return makeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
+	return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas)
 }
 
 func MakeSinkService(sink *v1alpha1.Sink) *corev1.Service {

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -30,9 +30,8 @@ func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
 	if sink.Spec.Pod.HPAutoscaler == nil {
 		return MakeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Kind)
-	} else {
-		return MakeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
 	}
+	return MakeHPA(objectMeta, sink.Spec.Pod.HPAutoscaler, sink.Kind)
 }
 
 func MakeSinkService(sink *v1alpha1.Sink) *corev1.Service {

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -28,10 +28,15 @@ import (
 
 func MakeSinkHPA(sink *v1alpha1.Sink) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSinkObjectMeta(sink)
-	if !isDefaultHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
-		return makeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Spec.Pod)
+	targetRef := autov2beta2.CrossVersionObjectReference{
+		Kind:       sink.Kind,
+		Name:       sink.Name,
+		APIVersion: sink.APIVersion,
 	}
-	return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas)
+	if !isDefaultHPAEnabled(sink.Spec.Replicas, sink.Spec.MaxReplicas, sink.Spec.Pod) {
+		return makeHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, sink.Spec.Pod, targetRef)
+	}
+	return makeDefaultHPA(objectMeta, *sink.Spec.Replicas, *sink.Spec.MaxReplicas, targetRef)
 }
 
 func MakeSinkService(sink *v1alpha1.Sink) *corev1.Service {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -28,10 +28,15 @@ import (
 
 func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSourceObjectMeta(source)
-	if !isDefaultHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
-		return makeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Spec.Pod)
+	targetRef := autov2beta2.CrossVersionObjectReference{
+		Kind:       source.Kind,
+		Name:       source.Name,
+		APIVersion: source.APIVersion,
 	}
-	return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas)
+	if !isDefaultHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
+		return makeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Spec.Pod, targetRef)
+	}
+	return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, targetRef)
 }
 
 func MakeSourceService(source *v1alpha1.Source) *corev1.Service {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -21,12 +21,12 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autov1 "k8s.io/api/autoscaling/v1"
+	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func MakeSourceHPA(source *v1alpha1.Source) *autov1.HorizontalPodAutoscaler {
+func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSourceObjectMeta(source)
 	return MakeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
 }

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -30,9 +30,8 @@ func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler
 	objectMeta := MakeSourceObjectMeta(source)
 	if source.Spec.Pod.HPAutoscaler == nil {
 		return MakeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
-	} else {
-		return MakeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
 	}
+	return MakeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
 }
 
 func MakeSourceService(source *v1alpha1.Source) *corev1.Service {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -33,7 +33,9 @@ func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler
 		Name:       source.Name,
 		APIVersion: source.APIVersion,
 	}
-	if !isDefaultHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
+	if isBuiltinHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
+		return makeBuiltinHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, targetRef, source.Spec.Pod.BuiltinAutoscaler)
+	} else if !isDefaultHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
 		return makeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Spec.Pod, targetRef)
 	}
 	return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, targetRef)

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -28,7 +28,11 @@ import (
 
 func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSourceObjectMeta(source)
-	return MakeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
+	if source.Spec.Pod.HPAutoscaler == nil {
+		return MakeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
+	} else {
+		return MakeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
+	}
 }
 
 func MakeSourceService(source *v1alpha1.Source) *corev1.Service {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -28,10 +28,10 @@ import (
 
 func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSourceObjectMeta(source)
-	if source.Spec.Pod.HPAutoscaler == nil {
-		return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
+	if !isDefaultHPAEnabled(source.Spec.Replicas, source.Spec.MaxReplicas, source.Spec.Pod) {
+		return makeHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Spec.Pod)
 	}
-	return makeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
+	return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas)
 }
 
 func MakeSourceService(source *v1alpha1.Source) *corev1.Service {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -29,9 +29,9 @@ import (
 func MakeSourceHPA(source *v1alpha1.Source) *autov2beta2.HorizontalPodAutoscaler {
 	objectMeta := MakeSourceObjectMeta(source)
 	if source.Spec.Pod.HPAutoscaler == nil {
-		return MakeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
+		return makeDefaultHPA(objectMeta, *source.Spec.Replicas, *source.Spec.MaxReplicas, source.Kind)
 	}
-	return MakeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
+	return makeHPA(objectMeta, source.Spec.Pod.HPAutoscaler, source.Kind)
 }
 
 func MakeSourceService(source *v1alpha1.Source) *corev1.Service {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -67,6 +67,7 @@ var _ = BeforeSuite(func(done Done) {
 				Paths: []string{filepath.Join("..", "config", "crd", "bases")},
 			},
 			AttachControlPlaneOutput: true,
+			ErrorIfCRDPathMissing:    true,
 		}
 	}
 	var err error

--- a/controllers/test_utils_test.go
+++ b/controllers/test_utils_test.go
@@ -18,13 +18,20 @@
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const TestClusterName string = "test-pulsar"
 const TestFunctionName string = "test-function"
+const TestFunctionE2EName string = "test-function-e2e"
+const TestFunctionKeyBatcherName string = "test-function-key-batcher"
+const TestFunctionHPAName string = "test-function-hpa"
+const TestFunctionBuiltinHPAName string = "test-function-builtin-hpa"
 const TestFunctionMeshName = "test-function-mesh"
 const TestSinkName string = "test-sink"
 const TestSourceName string = "test-source"
@@ -34,7 +41,7 @@ func makeSampleObjectMeta(name string) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: TestNameSpace,
-		UID:       "dead-beef", // uid not generate automatically with fake k8s
+		UID:       types.UID(fmt.Sprintf("dead-beef-%s", name)), // uid not generate automatically with fake k8s
 	}
 }
 
@@ -102,7 +109,7 @@ func makeFunctionSample(functionName string) *v1alpha1.Function {
 }
 
 func makeFunctionSampleWithCryptoEnabled() *v1alpha1.Function {
-	function := makeFunctionSample(TestFunctionName)
+	function := makeFunctionSample(TestFunctionE2EName)
 	function.Spec.Input = v1alpha1.InputConf{
 		Topics: []string{
 			"persistent://public/default/java-function-input-topic",
@@ -137,7 +144,7 @@ func makeFunctionSampleWithCryptoEnabled() *v1alpha1.Function {
 }
 
 func makeFunctionSampleWithKeyBasedBatcher() *v1alpha1.Function {
-	function := makeFunctionSample(TestFunctionName)
+	function := makeFunctionSample(TestFunctionKeyBatcherName)
 	function.Spec.Output = v1alpha1.OutputConf{
 		Topic: "persistent://public/default/java-function-output-topic",
 		ProducerConf: &v1alpha1.ProducerConfig{

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -82,7 +82,7 @@ done
 
 clusterName=${clusterName:-pulsar-dev}
 nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.15.12}
+k8sVersion=${k8sVersion:-v1.17.17}
 volumeNum=${volumeNum:-9}
 
 echo "clusterName: ${clusterName}"

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -82,7 +82,7 @@ done
 
 clusterName=${clusterName:-pulsar-dev}
 nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.17.17}
+k8sVersion=${k8sVersion:-v1.15.12}
 volumeNum=${volumeNum:-9}
 
 echo "clusterName: ${clusterName}"
@@ -239,10 +239,6 @@ $KUBECTL_BIN apply -f ${PULSAR_CHART_HOME}/manifests/local-dind/local-volume-pro
 docker pull gcr.io/google-containers/kube-scheduler:${k8sVersion}
 docker tag gcr.io/google-containers/kube-scheduler:${k8sVersion} mirantis/hypokube:final
 kind load docker-image --name=${clusterName} mirantis/hypokube:final
-
-echo "install metrics-server"
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
-kubectl patch deployment metrics-server -n kube-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls","--kubelet-preferred-address-types=InternalIP"]}]}}}}'
 
 echo "############# success create cluster:[${clusterName}] #############"
 

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -118,6 +118,8 @@ configFile=${workDir}/kind-config.yaml
 cat <<EOF > ${configFile}
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+runtimeConfig:
+  "autoscaling/v2beta2": "true"
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -237,6 +239,10 @@ $KUBECTL_BIN apply -f ${PULSAR_CHART_HOME}/manifests/local-dind/local-volume-pro
 docker pull gcr.io/google-containers/kube-scheduler:${k8sVersion}
 docker tag gcr.io/google-containers/kube-scheduler:${k8sVersion} mirantis/hypokube:final
 kind load docker-image --name=${clusterName} mirantis/hypokube:final
+
+echo "install metrics-server"
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+kubectl patch deployment metrics-server -n kube-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls","--kubelet-preferred-address-types=InternalIP"]}]}}}}'
 
 echo "############# success create cluster:[${clusterName}] #############"
 

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -476,6 +476,277 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
+                        type: object
                       imagePullSecrets:
                         items:
                           properties:
@@ -2649,6 +2920,277 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
+                        type: object
                       imagePullSecrets:
                         items:
                           properties:
@@ -4801,6 +5343,277 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        type: object
+                      hpAutoscaler:
+                        properties:
+                          behavior:
+                            properties:
+                              scaleDown:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              scaleUp:
+                                properties:
+                                  policies:
+                                    items:
+                                      properties:
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                        value:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                      type: object
+                                    type: array
+                                  selectPolicy:
+                                    type: string
+                                  stabilizationWindowSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          maxReplicas:
+                            format: int32
+                            type: integer
+                          metrics:
+                            items:
+                              properties:
+                                external:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                object:
+                                  properties:
+                                    describedObject:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                  type: object
+                                pods:
+                                  properties:
+                                    metric:
+                                      properties:
+                                        name:
+                                          type: string
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - metric
+                                  - target
+                                  type: object
+                                resource:
+                                  properties:
+                                    name:
+                                      type: string
+                                    target:
+                                      properties:
+                                        averageUtilization:
+                                          format: int32
+                                          type: integer
+                                        averageValue:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - target
+                                  type: object
+                                type:
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
                         type: object
                       imagePullSecrets:
                         items:
@@ -7114,6 +7927,277 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
+                  type: object
                 imagePullSecrets:
                   items:
                     properties:
@@ -9351,6 +10435,277 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
+                  type: object
                 imagePullSecrets:
                   items:
                     properties:
@@ -11567,6 +12922,277 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
+                  type: object
+                hpAutoscaler:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - periodSeconds
+                                - type
+                                - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          object:
+                            properties:
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - describedObject
+                            - metric
+                            - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
+                                    type: string
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - metric
+                            - target
+                            type: object
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - target
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                    scaleTargetRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                  required:
+                  - maxReplicas
+                  - scaleTargetRef
                   type: object
                 imagePullSecrets:
                   items:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -723,6 +723,10 @@ spec:
                           - type
                           type: object
                         type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -3143,6 +3147,10 @@ spec:
                           - type
                           type: object
                         type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -5542,6 +5550,10 @@ spec:
                           required:
                           - type
                           type: object
+                        type: array
+                      builtinAutoscaler:
+                        items:
+                          type: string
                         type: array
                       imagePullSecrets:
                         items:
@@ -8102,6 +8114,10 @@ spec:
                     - type
                     type: object
                   type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:
@@ -10586,6 +10602,10 @@ spec:
                     - type
                     type: object
                   type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:
@@ -13049,6 +13069,10 @@ spec:
                     required:
                     - type
                     type: object
+                  type: array
+                builtinAutoscaler:
+                  items:
+                    type: string
                   type: array
                 imagePullSecrets:
                   items:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -476,277 +476,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -2920,277 +2896,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -5344,277 +5296,253 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      hpAutoscaler:
+                      autoScalingBehavior:
                         properties:
-                          behavior:
+                          scaleDown:
                             properties:
-                              scaleDown:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              scaleUp:
-                                properties:
-                                  policies:
-                                    items:
-                                      properties:
-                                        periodSeconds:
-                                          format: int32
-                                          type: integer
-                                        type:
-                                          type: string
-                                        value:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                      type: object
-                                    type: array
-                                  selectPolicy:
-                                    type: string
-                                  stabilizationWindowSeconds:
-                                    format: int32
-                                    type: integer
-                                type: object
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
                             type: object
-                          maxReplicas:
-                            format: int32
-                            type: integer
-                          metrics:
-                            items:
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      autoScalingMetrics:
+                        items:
+                          properties:
+                            external:
                               properties:
-                                external:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                object:
-                                  properties:
-                                    describedObject:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                  type: object
-                                pods:
-                                  properties:
-                                    metric:
-                                      properties:
-                                        name:
-                                          type: string
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                      required:
-                                      - name
-                                      type: object
-                                    target:
-                                      properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  required:
-                                  - metric
-                                  - target
-                                  type: object
-                                resource:
+                                metric:
                                   properties:
                                     name:
                                       type: string
-                                    target:
+                                    selector:
                                       properties:
-                                        averageUtilization:
-                                          format: int32
-                                          type: integer
-                                        averageValue:
-                                          type: string
-                                        type:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - type
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       type: object
                                   required:
                                   - name
-                                  - target
                                   type: object
-                                type:
-                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                               required:
-                              - type
+                              - metric
+                              - target
                               type: object
-                            type: array
-                          minReplicas:
-                            format: int32
-                            type: integer
-                          scaleTargetRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                        required:
-                        - maxReplicas
-                        - scaleTargetRef
-                        type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
                       imagePullSecrets:
                         items:
                           properties:
@@ -7927,277 +7855,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:
@@ -10435,277 +10339,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:
@@ -12923,277 +12803,253 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                hpAutoscaler:
+                autoScalingBehavior:
                   properties:
-                    behavior:
+                    scaleDown:
                       properties:
-                        scaleDown:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        scaleUp:
-                          properties:
-                            policies:
-                              items:
-                                properties:
-                                  periodSeconds:
-                                    format: int32
-                                    type: integer
-                                  type:
-                                    type: string
-                                  value:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - periodSeconds
-                                - type
-                                - value
-                                type: object
-                              type: array
-                            selectPolicy:
-                              type: string
-                            stabilizationWindowSeconds:
-                              format: int32
-                              type: integer
-                          type: object
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
                       type: object
-                    maxReplicas:
-                      format: int32
-                      type: integer
-                    metrics:
-                      items:
+                    scaleUp:
+                      properties:
+                        policies:
+                          items:
+                            properties:
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              type:
+                                type: string
+                              value:
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          type: string
+                        stabilizationWindowSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                autoScalingMetrics:
+                  items:
+                    properties:
+                      external:
                         properties:
-                          external:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          object:
-                            properties:
-                              describedObject:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - describedObject
-                            - metric
-                            - target
-                            type: object
-                          pods:
-                            properties:
-                              metric:
-                                properties:
-                                  name:
-                                    type: string
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              target:
-                                properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            required:
-                            - metric
-                            - target
-                            type: object
-                          resource:
+                          metric:
                             properties:
                               name:
                                 type: string
-                              target:
+                              selector:
                                 properties:
-                                  averageUtilization:
-                                    format: int32
-                                    type: integer
-                                  averageValue:
-                                    type: string
-                                  type:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - type
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 type: object
                             required:
                             - name
-                            - target
                             type: object
-                          type:
-                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
                         required:
-                        - type
+                        - metric
+                        - target
                         type: object
-                      type: array
-                    minReplicas:
-                      format: int32
-                      type: integer
-                    scaleTargetRef:
-                      properties:
-                        apiVersion:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                  required:
-                  - maxReplicas
-                  - scaleTargetRef
-                  type: object
+                      object:
+                        properties:
+                          describedObject:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - describedObject
+                        - metric
+                        - target
+                        type: object
+                      pods:
+                        properties:
+                          metric:
+                            properties:
+                              name:
+                                type: string
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - metric
+                        - target
+                        type: object
+                      resource:
+                        properties:
+                          name:
+                            type: string
+                          target:
+                            properties:
+                              averageUtilization:
+                                format: int32
+                                type: integer
+                              averageValue:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                        required:
+                        - name
+                        - target
+                        type: object
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
                 imagePullSecrets:
                   items:
                     properties:


### PR DESCRIPTION
- upgrade `autoscaling/v1` to `autoscaling/v2beta2`
- add default HPA to make `maxReplicas` backward compatibility 
- add `autoScalingMetrics` and `autoScalingBehavior` to `PodPolicy` to allow user customize `HorizontalPodAutoscalerSpec`
- add `builtinAutoscaler` to support builtin HPA rules
- add builtin HPA rules
- add integration test of HPA and Builtin HPA
- add metrics-server to integration test kind cluster