### PR TITLE
add labels to related resources like `Service`

### DIFF
--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -43,6 +43,7 @@ const (
 	DefaultGoRunnerImage       = DefaultRunnerPrefix + "pulsar-functions-go-runner:" + DefaultRunnerTag
 	PulsarAdminExecutableFile  = "/pulsar/bin/pulsar-admin"
 
+	AppFunctionMesh   = "function-mesh"
 	ComponentSource   = "source"
 	ComponentSink     = "sink"
 	ComponentFunction = "function"
@@ -82,6 +83,10 @@ func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev
 				Name:     "grpc",
 				Protocol: corev1.ProtocolTCP,
 				Port:     GRPCPort.ContainerPort,
+			}, {
+				Name:     "metrics",
+				Protocol: corev1.ProtocolTCP,
+				Port:     MetricsPort.ContainerPort,
 			}},
 			Selector:  labels,
 			ClusterIP: "None",

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -61,6 +61,7 @@ func MakeFunctionObjectMeta(function *v1alpha1.Function) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      makeJobName(function.Name, v1alpha1.FunctionComponent),
 		Namespace: function.Namespace,
+		Labels:    makeFunctionLabels(function),
 		OwnerReferences: []metav1.OwnerReference{
 			*metav1.NewControllerRef(function, function.GroupVersionKind()),
 		},
@@ -100,6 +101,7 @@ func MakeFunctionContainer(function *v1alpha1.Function) *corev1.Container {
 
 func makeFunctionLabels(function *v1alpha1.Function) map[string]string {
 	labels := make(map[string]string)
+	labels["app"] = AppFunctionMesh
 	labels["component"] = ComponentFunction
 	labels["name"] = function.Name
 	labels["namespace"] = function.Namespace

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -62,6 +62,7 @@ func MakeSinkObjectMeta(sink *v1alpha1.Sink) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      makeJobName(sink.Name, v1alpha1.SinkComponent),
 		Namespace: sink.Namespace,
+		Labels:    MakeSinkLabels(sink),
 		OwnerReferences: []metav1.OwnerReference{
 			*metav1.NewControllerRef(sink, sink.GroupVersionKind()),
 		},

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -57,6 +57,7 @@ func MakeSourceObjectMeta(source *v1alpha1.Source) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      makeJobName(source.Name, v1alpha1.SourceComponent),
 		Namespace: source.Namespace,
+		Labels:    makeSourceLabels(source),
 		OwnerReferences: []metav1.OwnerReference{
 			*metav1.NewControllerRef(source, source.GroupVersionKind()),
 		},


### PR DESCRIPTION
for some cases, the user's cluster may not collect metrics with Prometheus scrape annotation but with `ServiceMonitor`, so this PR adds the related labels to other related resources, like `Service`, to make `ServiceMonitor` work with the label selector.

- add labels to related resources like `Service`
- add `app=function-mesh` label for selector use