### PR TITLE
remove unnecessary CAP_FOWNER Capability

### DIFF
--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -96,9 +96,6 @@ func MakeFunctionContainer(function *v1alpha1.Function) *corev1.Container {
 		ImagePullPolicy: imagePullPolicy,
 		EnvFrom:         generateContainerEnvFrom(function.Spec.Pulsar.PulsarConfig, function.Spec.Pulsar.AuthSecret, function.Spec.Pulsar.TLSSecret),
 		VolumeMounts:    makeFunctionVolumeMounts(function),
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_FOWNER"}},
-		},
 	}
 }
 

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -85,9 +85,6 @@ func MakeSinkContainer(sink *v1alpha1.Sink) *corev1.Container {
 		ImagePullPolicy: imagePullPolicy,
 		EnvFrom:         generateContainerEnvFrom(sink.Spec.Pulsar.PulsarConfig, sink.Spec.Pulsar.AuthSecret, sink.Spec.Pulsar.TLSSecret),
 		VolumeMounts:    makeSinkVolumeMounts(sink),
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_FOWNER"}},
-		},
 	}
 }
 

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -80,9 +80,6 @@ func MakeSourceContainer(source *v1alpha1.Source) *corev1.Container {
 		ImagePullPolicy: imagePullPolicy,
 		EnvFrom:         generateContainerEnvFrom(source.Spec.Pulsar.PulsarConfig, source.Spec.Pulsar.AuthSecret, source.Spec.Pulsar.TLSSecret),
 		VolumeMounts:    makeSourceVolumeMounts(source),
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"CAP_FOWNER"}},
-		},
 	}
 }
 


### PR DESCRIPTION
`CAP_FOWNER ` was added to validate go runtime since it requires `chmod`, but it has been proved that it is not need for default user cases, so this PR removes the capability.