### PR TITLE
Add annotation to exclude the webhook port from Istio proxying

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,9 +21,12 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: '9443'
       labels:
         control-plane: controller-manager
         app: function-mesh-operator
+        service.istio.io/canonical-name: function-mesh-operator
     spec:
       containers:
       - command:


### PR DESCRIPTION
Part of https://github.com/streamnative/data-plane-epics/issues/4