### PR TITLE
fix webhook service

### DIFF
--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: setup kubebuilder 2.3.1
         if: steps.list-changed.outputs.changed == 'true'
-        uses: RyanSiu1995/kubebuilder-action@v1.1
+        uses: RyanSiu1995/kubebuilder-action@v1.2.1
         with:
           version: 2.3.1
 

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -71,7 +71,7 @@ jobs:
           done
           make deploy
           kubectl get crds
-          kubectl wait --for condition=available --timeout=360s deployment/controller-manager
+          kubectl wait --for condition=available --timeout=360s deployment/function-mesh-controller-manager
 
       - name: Test Function kind - Java Function
         run: |

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -45,7 +45,6 @@ jobs:
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 
       - name: setup kubebuilder 2.3.1
-        if: steps.list-changed.outputs.changed == 'true'
         uses: RyanSiu1995/kubebuilder-action@v1.1
         with:
           version: 2.3.1

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -30,6 +30,7 @@ jobs:
           retry_on: error
           command: |
             .ci/deploy_pulsar_cluster.sh
+            helm install cert-manager --namespace sn-system jetstack/cert-manager --set installCRDs=true
           on_retry_command: |
             .ci/cleanup.sh
 

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -30,6 +30,8 @@ jobs:
           retry_on: error
           command: |
             .ci/deploy_pulsar_cluster.sh
+            helm repo add jetstack https://charts.jetstack.io
+            helm repo update
             helm install cert-manager --namespace sn-system jetstack/cert-manager --set installCRDs=true
           on_retry_command: |
             .ci/cleanup.sh

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -132,3 +132,7 @@ jobs:
         run: |
           .ci/verify_function_mesh.sh compute_v1alpha1_function_builtin_hpa
           kubectl delete -f .ci/clusters/compute_v1alpha1_function_builtin_hpa.yaml
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: failure()

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -45,7 +45,7 @@ jobs:
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 
       - name: setup kubebuilder 2.3.1
-        uses: RyanSiu1995/kubebuilder-action@v1.1
+        uses: RyanSiu1995/kubebuilder-action@v1.2.1
         with:
           version: 2.3.1
 

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -44,6 +44,12 @@ jobs:
           curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 
+      - name: setup kubebuilder 2.3.1
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: RyanSiu1995/kubebuilder-action@v1.1
+        with:
+          version: 2.3.1
+
       #      - name: Add CRD, controller or webhooks
       #        run: |
       #          operator-sdk create api --group compute --version v1alpha1 --kind Function --resource=true --controller=true

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -53,7 +53,17 @@ jobs:
         run: |
           make generate
           make install
-          nohup make run &
+          make docker-build
+          IMG=$(make function-mesh-docker-image-name)
+          clusters=$(kind get clusters)
+          echo $clusters
+          for cluster in $clusters
+          do
+          kind load docker-image --name ${cluster} ${IMG}
+          done
+          make deploy
+          kubectl get crds
+          kubectl wait --for condition=available --timeout=360s deployment/controller-manager
 
       - name: Test Function kind - Java Function
         run: |

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           make generate
           make install
-          make docker-build
+          make docker-build-skip-test
           IMG=$(make function-mesh-docker-image-name)
           clusters=$(kind get clusters)
           echo $clusters

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -32,7 +32,7 @@ jobs:
             .ci/deploy_pulsar_cluster.sh
             helm repo add jetstack https://charts.jetstack.io
             helm repo update
-            helm install cert-manager --namespace sn-system jetstack/cert-manager --set installCRDs=true
+            helm install cert-manager jetstack/cert-manager --set installCRDs=true
           on_retry_command: |
             .ci/cleanup.sh
 

--- a/Makefile
+++ b/Makefile
@@ -223,3 +223,6 @@ version:
 
 operator-docker-image-name:
 	@echo ${OPERATOR_IMG}
+
+function-mesh-docker-image-name:
+	@echo ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -226,3 +226,7 @@ operator-docker-image-name:
 
 function-mesh-docker-image-name:
 	@echo ${IMG}
+
+# Build the docker image without tests
+docker-build-skip-test:
+	docker build . -t ${IMG}

--- a/api/v1alpha1/function_webhook.go
+++ b/api/v1alpha1/function_webhook.go
@@ -110,7 +110,7 @@ func (r *Function) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=mfunction.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
+// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=vfunction.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Validator = &Function{}
 

--- a/api/v1alpha1/function_webhook.go
+++ b/api/v1alpha1/function_webhook.go
@@ -38,8 +38,7 @@ func (r *Function) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
-// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-function,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,verbs=create;update,versions=v1alpha1,name=mfunction.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-function,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,verbs=create;update,versions=v1alpha1,name=mfunction.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Defaulter = &Function{}
 
@@ -111,7 +110,7 @@ func (r *Function) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=vsink.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=vsink.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Validator = &Function{}
 
@@ -127,16 +126,20 @@ func (r *Function) ValidateCreate() error {
 	}
 
 	if r.Spec.Runtime.Java == nil && r.Spec.Runtime.Python == nil && r.Spec.Runtime.Golang == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java, "runtime cannot be empty"))
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "python"), r.Spec.Runtime.Python, "runtime cannot be empty"))
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "golang"), r.Spec.Runtime.Golang, "runtime cannot be empty"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java,
+			"runtime cannot be empty"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "python"), r.Spec.Runtime.Python,
+			"runtime cannot be empty"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "golang"), r.Spec.Runtime.Golang,
+			"runtime cannot be empty"))
 	}
 
 	if (r.Spec.Runtime.Java != nil && r.Spec.Runtime.Python != nil) ||
 		(r.Spec.Runtime.Java != nil && r.Spec.Runtime.Golang != nil) ||
 		(r.Spec.Runtime.Python != nil && r.Spec.Runtime.Golang != nil) ||
 		(r.Spec.Runtime.Java != nil && r.Spec.Runtime.Python != nil && r.Spec.Runtime.Golang != nil) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime"), r.Spec.Runtime, "you can only specify one runtime"))
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("runtime"), r.Spec.Runtime, "you can only specify one runtime"))
 	}
 
 	fieldErrs = validateJavaRuntime(r.Spec.Java, r.Spec.ClassName)

--- a/api/v1alpha1/function_webhook.go
+++ b/api/v1alpha1/function_webhook.go
@@ -110,7 +110,7 @@ func (r *Function) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=vsink.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
+// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-function,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=functions,versions=v1alpha1,name=mfunction.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Validator = &Function{}
 

--- a/api/v1alpha1/sink_webhook.go
+++ b/api/v1alpha1/sink_webhook.go
@@ -39,7 +39,7 @@ func (r *Sink) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-sink,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=sinks,verbs=create;update,versions=v1alpha1,name=msink.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-sink,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=sinks,verbs=create;update,versions=v1alpha1,name=msink.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Defaulter = &Sink{}
 
@@ -97,7 +97,7 @@ func (r *Sink) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-sink,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=sinks,versions=v1alpha1,name=vsink.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-sink,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=sinks,versions=v1alpha1,name=vsink.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Validator = &Sink{}
 
@@ -109,11 +109,13 @@ func (r *Sink) ValidateCreate() error {
 	var fieldErrs []*field.Error
 
 	if r.Spec.SinkConfig == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("sinkConfig"), r.Spec.SinkConfig, "sink config is not provided"))
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("sinkConfig"), r.Spec.SinkConfig, "sink config is not provided"))
 	}
 
 	if r.Spec.Runtime.Java == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java, "sink must have java runtime specified"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java,
+			"sink must have java runtime specified"))
 	}
 
 	fieldErrs = validateJavaRuntime(r.Spec.Java, r.Spec.ClassName)

--- a/api/v1alpha1/source_webhook.go
+++ b/api/v1alpha1/source_webhook.go
@@ -39,7 +39,7 @@ func (r *Source) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-source,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=sources,verbs=create;update,versions=v1alpha1,name=msource.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-compute-functionmesh-io-v1alpha1-source,mutating=true,failurePolicy=fail,groups=compute.functionmesh.io,resources=sources,verbs=create;update,versions=v1alpha1,name=msource.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Defaulter = &Source{}
 
@@ -107,7 +107,7 @@ func (r *Source) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-source,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=sources,versions=v1alpha1,name=vsource.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-compute-functionmesh-io-v1alpha1-source,mutating=false,failurePolicy=fail,groups=compute.functionmesh.io,resources=sources,versions=v1alpha1,name=vsource.kb.io,sideEffects=none,admissionReviewVersions={v1beta1,v1}
 
 var _ webhook.Validator = &Source{}
 
@@ -119,11 +119,13 @@ func (r *Source) ValidateCreate() error {
 	var fieldErrs []*field.Error
 
 	if r.Spec.SourceConfig == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("sourceConfig"), r.Spec.SourceConfig, "source config is not provided"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("sourceConfig"), r.Spec.SourceConfig,
+			"source config is not provided"))
 	}
 
 	if r.Spec.Runtime.Java == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java, "source must have java runtime specified"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("runtime", "java"), r.Spec.Runtime.Java,
+			"source must have java runtime specified"))
 	}
 
 	fieldErrs = validateJavaRuntime(r.Spec.Java, r.Spec.ClassName)

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,8 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -18,8 +17,8 @@ metadata:
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -46,7 +46,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -54,7 +54,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,6 +18,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app: function-mesh-operator
+      service.istio.io/canonical-name: function-mesh-operator
   replicas: 1
   template:
     metadata:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,6 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app: function-mesh-operator
-      service.istio.io/canonical-name: function-mesh-operator
   replicas: 1
   template:
     metadata:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -7,6 +7,7 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:
@@ -27,6 +28,7 @@ webhooks:
     - functions
   sideEffects: None
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:
@@ -47,6 +49,7 @@ webhooks:
     - sinks
   sideEffects: None
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:
@@ -75,6 +78,7 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:
@@ -95,6 +99,7 @@ webhooks:
     - functions
   sideEffects: None
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:
@@ -115,6 +120,7 @@ webhooks:
     - sinks
   sideEffects: None
 - admissionReviewVersions:
+  - v1beta1
   - v1
   clientConfig:
     service:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -86,7 +86,7 @@ webhooks:
       namespace: system
       path: /validate-compute-functionmesh-io-v1alpha1-function
   failurePolicy: Fail
-  name: mfunction.kb.io
+  name: vfunction.kb.io
   rules:
   - apiGroups:
     - compute.functionmesh.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -86,7 +86,7 @@ webhooks:
       namespace: system
       path: /validate-compute-functionmesh-io-v1alpha1-function
   failurePolicy: Fail
-  name: vsink.kb.io
+  name: mfunction.kb.io
   rules:
   - apiGroups:
     - compute.functionmesh.io

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -13,4 +13,5 @@ spec:
   selector:
     control-plane: controller-manager
     app: function-mesh-operator
+    service.istio.io/canonical-name: function-mesh-operator
 

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -14,4 +14,3 @@ spec:
     control-plane: controller-manager
     app: function-mesh-operator
     service.istio.io/canonical-name: function-mesh-operator
-

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -4,9 +4,14 @@ kind: Service
 metadata:
   name: webhook-service
   namespace: system
+  annotations:
+    traffic.sidecar.istio.io/excludeInboundPorts: "9443"
 spec:
   ports:
     - port: 443
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app: function-mesh-operator
+    service.istio.io/canonical-name: function-mesh-operator
+

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -13,5 +13,4 @@ spec:
   selector:
     control-plane: controller-manager
     app: function-mesh-operator
-    service.istio.io/canonical-name: function-mesh-operator
 

--- a/license_test.go
+++ b/license_test.go
@@ -72,6 +72,7 @@ var skip = map[string]bool{
 	".github/workflows/release-node.yml": true,
 	"hack/webhook-create-signed-cert.sh": true,
 	"hack/webhooks/certs/csr.conf":       true,
+	"pulsar-charts":                      true,
 }
 
 func TestLicense(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -143,7 +143,10 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Sink")
 		os.Exit(1)
 	}
-	if os.Getenv("ENABLE_WEBHOOKS") == "true" {
+
+	// enable the webhook service by default
+	// Disable function-mesh webhook with `ENABLE_WEBHOOKS=false` when we run locally.
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&computev1alpha1.Function{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Function")
 			os.Exit(1)


### PR DESCRIPTION
fix #326 #340
- enable webhook in CI action
- add `service.istio.io/canonical-name` label to operator
- add exclusion rule for istio
- fix webhook admission versions error `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Internal error occurred: failed calling webhook \"msink.kb.io\": expected response.uid=\"ab833ac7-5bdb-4bd8-98c9-d4a91aac27c9\", got \"\"","reason":"InternalError","details":{"causes":[{"message":"failed calling webhook \"msink.kb.io\": expected response.uid=\"ab833ac7-5bdb-4bd8-98c9-d4a91aac27c9\", got \"\""}]},"code":500}`
- enable webhook by default, and disable by ENV `ENABLE_WEBHOOKS=false`