### PR TITLE
apply istio service port name convention to function-mesh services

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: https-metrics-service
     port: 8443
     targetPort: https
   selector:

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -10,6 +10,7 @@ spec:
   ports:
     - port: 443
       targetPort: 9443
+      name: https-webhook-service
   selector:
     control-plane: controller-manager
     app: function-mesh-operator

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -64,13 +64,13 @@ const (
 )
 
 var GRPCPort = corev1.ContainerPort{
-	Name:          "grpc",
+	Name:          "tcp-grpc",
 	ContainerPort: 9093,
 	Protocol:      corev1.ProtocolTCP,
 }
 
 var MetricsPort = corev1.ContainerPort{
-	Name:          "metrics",
+	Name:          "tcp-metrics",
 	ContainerPort: 9094,
 	Protocol:      corev1.ProtocolTCP,
 }
@@ -84,17 +84,9 @@ func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev
 		},
 		ObjectMeta: *objectMeta,
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Name:     "grpc",
-				Protocol: corev1.ProtocolTCP,
-				Port:     GRPCPort.ContainerPort,
-			}, {
-				Name:     "metrics",
-				Protocol: corev1.ProtocolTCP,
-				Port:     MetricsPort.ContainerPort,
-			}},
+			Ports:     []corev1.ServicePort{toServicePort(&GRPCPort), toServicePort(&MetricsPort)},
 			Selector:  labels,
-			ClusterIP: "None",
+			ClusterIP: corev1.ClusterIPNone,
 		},
 	}
 }

--- a/controllers/spec/utils.go
+++ b/controllers/spec/utils.go
@@ -23,6 +23,9 @@ import (
 	"regexp"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/streamnative/function-mesh/api/v1alpha1"
@@ -407,4 +410,12 @@ func getInt32FromPtrOrDefault(ptr *int32, val int32) int32 {
 		ret = *ptr
 	}
 	return ret
+}
+
+func toServicePort(port *corev1.ContainerPort) corev1.ServicePort {
+	return corev1.ServicePort{
+		Name:       port.Name,
+		Port:       port.ContainerPort,
+		TargetPort: intstr.FromInt(int(port.ContainerPort)),
+	}
 }

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -249,7 +249,7 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: https-metrics-service
     port: 8443
     targetPort: https
   selector:


### PR DESCRIPTION
Fixes #326 

### Motivation

apply function-mesh services with [Istio service port naming convention](https://istio.io/latest/docs/ops/deployment/requirements/) 

ref: https://istio.io/latest/docs/reference/config/analysis/ist0118/

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

