### PR TITLE
Support specifying an object as unmanaged.

### DIFF
--- a/controllers/function_controller.go
+++ b/controllers/function_controller.go
@@ -19,9 +19,9 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
+	"github.com/streamnative/function-mesh/controllers/spec"
 	appsv1 "k8s.io/api/apps/v1"
 	autov2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -59,6 +59,11 @@ func (r *FunctionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		r.Log.Error(err, "failed to get function")
 		return reconcile.Result{}, err
+	}
+	
+	if !spec.IsManaged(function) {
+		r.Log.Info("Skipping function not managed by the controller", "Name", req.String())
+		return reconcile.Result{}, nil
 	}
 
 	// initialize component status map

--- a/controllers/function_controller.go
+++ b/controllers/function_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
 	"github.com/streamnative/function-mesh/controllers/spec"
@@ -60,7 +61,7 @@ func (r *FunctionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		r.Log.Error(err, "failed to get function")
 		return reconcile.Result{}, err
 	}
-	
+
 	if !spec.IsManaged(function) {
 		r.Log.Info("Skipping function not managed by the controller", "Name", req.String())
 		return reconcile.Result{}, nil

--- a/controllers/functionmesh_controller.go
+++ b/controllers/functionmesh_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"
 	"github.com/streamnative/function-mesh/api/v1alpha1"
@@ -54,6 +55,12 @@ func (r *FunctionMeshReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		r.Log.Error(err, "failed to get mesh")
 		return reconcile.Result{Requeue: true}, err
 	}
+
+	if !spec.IsManaged(mesh) {
+		r.Log.Info("Skipping function mesh not managed by the controller", "Name", req.String())
+		return reconcile.Result{}, nil
+	}
+	
 	// initialize component status map
 	if mesh.Status.FunctionConditions == nil {
 		mesh.Status.FunctionConditions = make(map[string]v1alpha1.ResourceCondition)

--- a/controllers/functionmesh_controller.go
+++ b/controllers/functionmesh_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"
@@ -60,7 +61,7 @@ func (r *FunctionMeshReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		r.Log.Info("Skipping function mesh not managed by the controller", "Name", req.String())
 		return reconcile.Result{}, nil
 	}
-	
+
 	// initialize component status map
 	if mesh.Status.FunctionConditions == nil {
 		mesh.Status.FunctionConditions = make(map[string]v1alpha1.ResourceCondition)

--- a/controllers/sink_controller.go
+++ b/controllers/sink_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"

--- a/controllers/sink_controller.go
+++ b/controllers/sink_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"
 	computev1alpha1 "github.com/streamnative/function-mesh/api/v1alpha1"
@@ -58,6 +59,11 @@ func (r *SinkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		r.Log.Error(err, "failed to get sink")
 		return reconcile.Result{}, err
+	}
+
+	if !spec.IsManaged(sink) {
+		r.Log.Info("Skipping sink not managed by the controller", "Name", req.String())
+		return reconcile.Result{}, nil
 	}
 
 	if sink.Status.Conditions == nil {

--- a/controllers/source_controller.go
+++ b/controllers/source_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"
 	computev1alpha1 "github.com/streamnative/function-mesh/api/v1alpha1"
@@ -58,6 +59,11 @@ func (r *SourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		r.Log.Error(err, "failed to get source")
 		return reconcile.Result{}, err
+	}
+
+	if !spec.IsManaged(source) {
+		r.Log.Info("Skipping source not managed by the controller", "Name", req.String())
+		return reconcile.Result{}, nil
 	}
 
 	if source.Status.Conditions == nil {

--- a/controllers/source_controller.go
+++ b/controllers/source_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/streamnative/function-mesh/controllers/spec"
 
 	"github.com/go-logr/logr"

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -51,9 +51,9 @@ const (
 	PackageNameSinkPrefix     = "sink://"
 	PackageNameSourcePrefix   = "source://"
 
-	AnnotationPrometheusScrape  = "prometheus.io/scrape"
-	AnnotationPrometheusPort    = "prometheus.io/port"
-	AnnotationManaged 			= "compute.functionmesh.io/managed"
+	AnnotationPrometheusScrape = "prometheus.io/scrape"
+	AnnotationPrometheusPort   = "prometheus.io/port"
+	AnnotationManaged          = "compute.functionmesh.io/managed"
 
 	EnvGoFunctionConfigs = "GO_FUNCTION_CONF"
 

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -53,7 +53,7 @@ const (
 
 	AnnotationPrometheusScrape  = "prometheus.io/scrape"
 	AnnotationPrometheusPort    = "prometheus.io/port"
-	AnnotationAppliedConfigHash = "config.functionmesh.io/applied"
+	AnnotationManaged 			= "compute.functionmesh.io/managed"
 
 	EnvGoFunctionConfigs = "GO_FUNCTION_CONF"
 
@@ -73,6 +73,11 @@ var MetricsPort = corev1.ContainerPort{
 	Name:          "tcp-metrics",
 	ContainerPort: 9094,
 	Protocol:      corev1.ProtocolTCP,
+}
+
+func IsManaged(object metav1.Object) bool {
+	managed, exists := object.GetAnnotations()[AnnotationManaged]
+	return !exists || managed != "false"
 }
 
 func MakeService(objectMeta *metav1.ObjectMeta, labels map[string]string) *corev1.Service {


### PR DESCRIPTION
resolves #376

### Motivation
Adding annotation compute.functionmesh.io/managed: false should make an object unmanged.

### Modifications
Controller will check for the annotation in reconcile loop and skip unmanaged objects.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-required` 
  Add doc about how to make an object unmanaged.