### PR TITLE
fix: convert the memory value to decimal format

### DIFF
--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -28,6 +28,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -707,4 +708,12 @@ func getPythonSecretProviderArgs(secretMaps map[string]v1alpha1.SecretRef) []str
 		}
 	}
 	return ret
+}
+
+// Java command requires memory values in resource.DecimalSI format
+func getDecimalSIMemory(quantity *resource.Quantity) string {
+	if quantity.Format == resource.DecimalSI {
+		return quantity.String()
+	}
+	return resource.NewQuantity(quantity.Value(), resource.DecimalSI).String()
 }

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -118,7 +118,7 @@ func makeFunctionCommand(function *v1alpha1.Function) []string {
 		if spec.Java.Jar != "" {
 			return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
 				spec.Name, spec.ClusterName, generateFunctionDetailsInJSON(function),
-				spec.Resources.Requests.Memory().String(), spec.Java.ExtraDependenciesDir, string(function.UID),
+				getDecimalSIMemory(spec.Resources.Requests.Memory()), spec.Java.ExtraDependenciesDir, string(function.UID),
 				spec.Pulsar.AuthSecret != "", spec.Pulsar.TLSSecret != "", function.Spec.SecretsMap,
 				function.Spec.StateConfig)
 		}

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -111,7 +111,7 @@ func MakeSinkCommand(sink *v1alpha1.Sink) []string {
 	spec := sink.Spec
 	return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
 		spec.Name, spec.ClusterName, generateSinkDetailsInJSON(sink),
-		spec.Resources.Requests.Memory().ToDec().String(), spec.Java.ExtraDependenciesDir, string(sink.UID),
+		getDecimalSIMemory(spec.Resources.Requests.Memory()), spec.Java.ExtraDependenciesDir, string(sink.UID),
 		spec.Pulsar.AuthSecret != "", spec.Pulsar.TLSSecret != "", spec.SecretsMap, nil)
 }
 

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -106,7 +106,7 @@ func makeSourceCommand(source *v1alpha1.Source) []string {
 	spec := source.Spec
 	return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
 		spec.Name, spec.ClusterName, generateSourceDetailsInJSON(source),
-		spec.Resources.Requests.Memory().ToDec().String(), spec.Java.ExtraDependenciesDir, string(source.UID),
+		getDecimalSIMemory(spec.Resources.Requests.Memory()), spec.Java.ExtraDependenciesDir, string(source.UID),
 		spec.Pulsar.AuthSecret != "", spec.Pulsar.TLSSecret != "", spec.SecretsMap, nil)
 }
 


### PR DESCRIPTION
Signed-off-by: laminar <tpiperatgod@gmail.com>
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #375 

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Java commands require memory values in [resource.DecimalSI](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format) format.

### Modifications

Convert memory values passed into the `MakeJavaFunctionCommand` function to decimal format

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

