### PR TITLE
Pass LeaderElectionNamespace when not in k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go --leader-election-namespace default
+	go run ./main.go --enable-leader-election=false
 
 # Install CRDs into a cluster
 install: manifests kustomize crd

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run ./main.go --leader-election-namespace default
 
 # Install CRDs into a cluster
 install: manifests kustomize crd

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go --enable-leader-election=false
+	go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests kustomize crd

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		"the name of the configmap that leader election will use for holding the leader lock.")
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "",
 		"the namespace in which the leader election configmap will be created")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&healthProbeAddr, "health-probe-addr", ":8000", "The address the healthz/readyz endpoint binds to.")

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const DEFAULT_ELECTION_NAMESPACE = "default"
+const DefaultElectionNamespace string = "default"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -58,7 +58,7 @@ func getLeaderElectionNamespace() string {
 		if isSet {
 			return namespace
 		}
-		return DEFAULT_ELECTION_NAMESPACE
+		return DefaultElectionNamespace
 	}
 
 	return ""


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
Fixes #382 

### Motivation

`LeaderElectionNamespace` is required when operator is running outside of k8s

### Modifications

get `LeaderElectionNamespace` from env `LEADER_ELECTION_NAMESPACE` or use `default`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

