### PR TITLE
Some small types fixed in readme and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	ENABLE_WEBHOOKS=false go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests kustomize crd

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/streamnative/function-mesh.git
 - install operator-sdk and use it to add CRD, controller or webhooks
 
 ```bash
-operator-sdk create api --group compute --version v1alpha1 --kind Function --resource=true --controller-true
+operator-sdk create api --group compute --version v1alpha1 --kind Function --resource=true --controller=true
 ```
 
 ```bash


### PR DESCRIPTION
### Motivation


I was following the README and found two small issues preventing me from running the code. 

### Modifications


One was a typo (_I think_) for the operator-sdk. The README has `--controller-true`. I think this is a mistake since I see the operation is `--controller=true` in the operator-sdk docs and cli on my computer.

The second issue I had was when running `make run`. Main.go would crash setting up the webhook. Reading https://github.com/streamnative/function-mesh/blob/4ed298a36a08af0d10a961cb69b4b3c775359f22/main.go#L151-L153, it seems ENABLE_WEBHOOKS should be set to false when running locally with `make run`. I've set it to thus. (An alternative 'fix' would be the README saying to run `ENABLE_WEBHOOKS=false make run` as opposed to `make run`.)

These may both be non-issues. Feel free to correct any misunderstanding I have.

Thanks!

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ x ] `doc-not-needed` 
It is cleaning up docs
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)