### PR TITLE
Use v1.8.2 for cert-manager tests

### DIFF
--- a/.ci/tests/integration/e2e.yaml
+++ b/.ci/tests/integration/e2e.yaml
@@ -17,7 +17,7 @@ setup:
       command: |
         helm repo add jetstack https://charts.jetstack.io
         helm repo update
-        helm install cert-manager jetstack/cert-manager --set installCRDs=true
+        helm install cert-manager jetstack/cert-manager --set installCRDs=true --version v1.8.2
       wait:
         - namespace: default
           resource: pod

--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --set installCRDs=true --version v1.8.2
 
       - name: Run chart-testing (install)
         run: ct install --config .ci/ct.yaml

--- a/.github/workflows/test-integration-kind-samples.yml
+++ b/.github/workflows/test-integration-kind-samples.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --set installCRDs=true --version v1.8.2
 
       - name: Build runner images
         run: |


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

the latest cert-manager(v1.9.0) chart is not compatible with k8s=v1.8.20

```
ERROR commands: [helm repo add jetstack [https://charts.jetstack.io\nhelm](https://charts.jetstack.io/nhelm) repo update\nhelm install cert-manager jetstack/cert-manager --set installCRDs=true\n] runs error: Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.19.0-0 which is incompatible with Kubernetes v1.18.20
```

### Modifications

Use cert-manager v1.8.2 in tests environment

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
  Fix tests
  

