### PR TITLE
Add a limit to the resource name

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -501,3 +501,7 @@ func CreateCondition(condType ResourceConditionType, status metav1.ConditionStat
 	}
 	return condition
 }
+
+const (
+	maxNameLength = 43
+)

--- a/api/v1alpha1/function_webhook.go
+++ b/api/v1alpha1/function_webhook.go
@@ -18,6 +18,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -120,6 +122,10 @@ func (r *Function) ValidateCreate() error {
 	var allErrs field.ErrorList
 	var fieldErr *field.Error
 	var fieldErrs []*field.Error
+
+	if len(r.Name) > maxNameLength {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("name"), r.Name, fmt.Sprintf("function name must be no more than %d characters", maxNameLength)))
+	}
 
 	if r.Name == "" {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("name"), r.Name, "function name is not provided"))

--- a/api/v1alpha1/sink_webhook.go
+++ b/api/v1alpha1/sink_webhook.go
@@ -18,6 +18,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -107,6 +109,10 @@ func (r *Sink) ValidateCreate() error {
 	var allErrs field.ErrorList
 	var fieldErr *field.Error
 	var fieldErrs []*field.Error
+
+	if len(r.Name) > maxNameLength {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("name"), r.Name, fmt.Sprintf("sink name must be no more than %d characters", maxNameLength)))
+	}
 
 	if r.Spec.SinkConfig == nil {
 		allErrs = append(allErrs,

--- a/api/v1alpha1/source_webhook.go
+++ b/api/v1alpha1/source_webhook.go
@@ -18,6 +18,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -117,6 +119,10 @@ func (r *Source) ValidateCreate() error {
 	var allErrs field.ErrorList
 	var fieldErr *field.Error
 	var fieldErrs []*field.Error
+
+	if len(r.Name) > maxNameLength {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("name"), r.Name, fmt.Sprintf("source name must be no more than %d characters", maxNameLength)))
+	}
 
 	if r.Spec.SourceConfig == nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("sourceConfig"), r.Spec.SourceConfig,


### PR DESCRIPTION
Signed-off-by: laminar <tpiperatgod@gmail.com>
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #436

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

function:

- sts name: -function, 9 fixed chars
- svc name: -function-headless, 18 fixed chars
- pod label controller-revision-hash: -function-<10 * chars>, 20 fixed chars
- hpa name: -function, 9 fixed chars

fixed chars length: 20, length of : 1~43

sink:

- sts name: -sink, 5 fixed chars
- svc name: -sink-headless, 14 fixed chars
- pod label controller-revision-hash: -sink-<10 * chars>, 16 fixed chars
- hpa name: -sink, 5 fixed chars

fixed chars length: 16, length of : 1~47

source:

- sts name: -source, 7 fixed chars
- svc name: -source-headless, 16 fixed chars
- pod label controller-revision-hash: -source-<10 * chars>, 18 fixed chars
- hpa name: -source, 7 fixed chars

fixed chars length: 18, length of : 1~45

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

