### PR TITLE
release 0.5.0 to openshift

### DIFF
--- a/.ci/olm-tests/catalog.yml
+++ b/.ci/olm-tests/catalog.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: kind-registry:5000/streamnativeio/function-mesh-catalog:v0.4.0
+  image: kind-registry:5000/streamnativeio/function-mesh-catalog:v0.5.0

--- a/.ci/olm-tests/subs.yml
+++ b/.ci/olm-tests/subs.yml
@@ -6,6 +6,6 @@ metadata:
 spec:
   channel: alpha
   name: function-mesh
-  startingCSV: function-mesh.v0.4.0
+  startingCSV: function-mesh.v0.5.0
   source: my-test-catalog
   sourceNamespace: olm


### PR DESCRIPTION
### Motivation
- https://github.com/redhat-openshift-ecosystem/certified-operators/pull/1155
- https://github.com/k8s-operatorhub/community-operators/pull/1615
- fix CI on 0.5.0 failure

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

