### PR TITLE
make java runner use different JDK based on pulsar version

### DIFF
--- a/images/build.sh
+++ b/images/build.sh
@@ -31,19 +31,19 @@ KIND_PUSH=${KIND_PUSH:-false}
 CI_TEST=${CI_TEST:-false}
 
 echo "build runner base"
-docker build -t ${RUNNER_BASE} images/pulsar-functions-base-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG"
+docker build -t ${RUNNER_BASE} images/pulsar-functions-base-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG" --progress=plain
 docker tag ${RUNNER_BASE} "${DOCKER_REPO}"/${RUNNER_BASE}:"${RUNNER_TAG}"
 
 echo "build java runner"
-docker build -t ${JAVA_RUNNER} images/pulsar-functions-java-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG"
+docker build -t ${JAVA_RUNNER} images/pulsar-functions-java-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG" --progress=plain
 docker tag ${JAVA_RUNNER} "${DOCKER_REPO}"/${JAVA_RUNNER}:"${RUNNER_TAG}"
 
 echo "build python runner"
-docker build -t ${PYTHON_RUNNER} images/pulsar-functions-python-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG"
+docker build -t ${PYTHON_RUNNER} images/pulsar-functions-python-runner --build-arg PULSAR_IMAGE="$PULSAR_IMAGE" --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG" --progress=plain
 docker tag ${PYTHON_RUNNER} "${DOCKER_REPO}"/${PYTHON_RUNNER}:"${RUNNER_TAG}"
 
 echo "build go runner"
-docker build -t ${GO_RUNNER} images/pulsar-functions-go-runner # go runner is almost the same as runner base, so we no need to given build args for go runner
+docker build -t ${GO_RUNNER} images/pulsar-functions-go-runner --progress=plain # go runner is almost the same as runner base, so we no need to given build args for go runner
 docker tag ${GO_RUNNER} "${DOCKER_REPO}"/${GO_RUNNER}:"${RUNNER_TAG}"
 
 if [ "$KIND_PUSH" = true ] ; then

--- a/images/pulsar-functions-base-runner/Dockerfile
+++ b/images/pulsar-functions-base-runner/Dockerfile
@@ -22,10 +22,10 @@ RUN mkdir -p /pulsar/bin/ \
 
 ARG PULSAR_IMAGE_TAG
 ENV VERSION_TAG=${PULSAR_IMAGE_TAG}
-RUN echo "VERSION_TAG=${VERSION_TAG}" && \
-    VERSION_MAJOR=`echo $VERSION_TAG | cut -d. -f1` && \
-    VERSION_MINOR=`echo $VERSION_TAG | cut -d. -f2` && \
-    VERSION_PATCH=`echo $VERSION_TAG | cut -d. -f3` && \
+RUN echo "VERSION_TAG=$(VERSION_TAG)" && \
+    VERSION_MAJOR=`echo $(VERSION_TAG) | cut -d. -f1` && \
+    VERSION_MINOR=`echo $(VERSION_TAG) | cut -d. -f2` && \
+    VERSION_PATCH=`echo $(VERSION_TAG) | cut -d. -f3` && \
     if [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 7 ]; then \
         echo "Pulsar version is 2.7, use java 1.8" && \
         export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \

--- a/images/pulsar-functions-base-runner/Dockerfile
+++ b/images/pulsar-functions-base-runner/Dockerfile
@@ -23,9 +23,9 @@ RUN mkdir -p /pulsar/bin/ \
 ARG PULSAR_IMAGE_TAG
 ENV VERSION_TAG=${PULSAR_IMAGE_TAG}
 RUN echo "VERSION_TAG=$(VERSION_TAG)" && \
-    VERSION_MAJOR=`echo $(VERSION_TAG) | cut -d. -f1` && \
-    VERSION_MINOR=`echo $(VERSION_TAG) | cut -d. -f2` && \
-    VERSION_PATCH=`echo $(VERSION_TAG) | cut -d. -f3` && \
+    VERSION_MAJOR=$(echo $VERSION_TAG | cut -d. -f1) && \
+    VERSION_MINOR=$(echo $VERSION_TAG | cut -d. -f2) && \
+    VERSION_PATCH=$(echo $VERSION_TAG | cut -d. -f3) && \
     if [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 7 ]; then \
         echo "Pulsar version is 2.7, use java 1.8" && \
         export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \

--- a/images/pulsar-functions-base-runner/Dockerfile
+++ b/images/pulsar-functions-base-runner/Dockerfile
@@ -27,22 +27,22 @@ RUN echo "VERSION_TAG=${VERSION_TAG}" && \
     VERSION_MINOR=`echo $VERSION_TAG | cut -d. -f2` && \
     VERSION_PATCH=`echo $VERSION_TAG | cut -d. -f3` && \
     if [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 7 ]; then \
-        echo "Pulsar version is 2.7, use jdk 8" && \
+        echo "Pulsar version is 2.7, use java 1.8" && \
         export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
     elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 8 ]; then \
-        echo "Pulsar version is 2.8, use jdk 8" && \
+        echo "Pulsar version is 2.8, use java 1.8" && \
         export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
     elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 9 ]; then \
-        echo "Pulsar version is 2.9, use jdk 8" && \
+        echo "Pulsar version is 2.9, use java 1.8" && \
         export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
     elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 10 ]; then \
-        echo "Pulsar version is 2.10, use jdk 11" && \
+        echo "Pulsar version is 2.10, use java 11" && \
         export JRE_PACKAGE_NAME=openjdk-11-jre-headless; \
     elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 11 ]; then \
-        echo "Pulsar version is 2.11, use jdk 17" && \
+        echo "Pulsar version is 2.11, use java 17" && \
         export JRE_PACKAGE_NAME=openjdk-17-jre-headless; \
     else \
-        echo "Pulsar version is not in the list, use jdk 17 instead" && \
+        echo "Pulsar version is not in the list, use java 17 instead" && \
         export JRE_PACKAGE_NAME=openjdk-17-jre-headless; \
     fi && \
     apt-get update \

--- a/images/pulsar-functions-base-runner/Dockerfile
+++ b/images/pulsar-functions-base-runner/Dockerfile
@@ -20,13 +20,38 @@ RUN mkdir -p /pulsar/bin/ \
     && chown -R $UID:$GID /pulsar \
     && chmod -R g=u /pulsar
 
-RUN apt-get update \
-     && apt-get -y dist-upgrade \
-     && apt-get -y install openjdk-11-jre-headless \
-     && apt-get -y --purge autoremove \
-     && apt-get autoclean \
-     && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
+ARG PULSAR_IMAGE_TAG
+ENV VERSION_TAG=${PULSAR_IMAGE_TAG}
+RUN echo "VERSION_TAG=${VERSION_TAG}" && \
+    VERSION_MAJOR=`echo $VERSION_TAG | cut -d. -f1` && \
+    VERSION_MINOR=`echo $VERSION_TAG | cut -d. -f2` && \
+    VERSION_PATCH=`echo $VERSION_TAG | cut -d. -f3` && \
+    if [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 7 ]; then \
+        echo "Pulsar version is 2.7, use jdk 8" && \
+        export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
+    elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 8 ]; then \
+        echo "Pulsar version is 2.8, use jdk 8" && \
+        export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
+    elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 9 ]; then \
+        echo "Pulsar version is 2.9, use jdk 8" && \
+        export JRE_PACKAGE_NAME=openjdk-8-jre-headless; \
+    elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 10 ]; then \
+        echo "Pulsar version is 2.10, use jdk 11" && \
+        export JRE_PACKAGE_NAME=openjdk-11-jre-headless; \
+    elif [ $VERSION_MAJOR -eq 2 ] && [ $VERSION_MINOR -eq 11 ]; then \
+        echo "Pulsar version is 2.11, use jdk 17" && \
+        export JRE_PACKAGE_NAME=openjdk-17-jre-headless; \
+    else \
+        echo "Pulsar version is not in the list, use jdk 17 instead" && \
+        export JRE_PACKAGE_NAME=openjdk-17-jre-headless; \
+    fi && \
+    apt-get update \
+         && apt-get -y dist-upgrade \
+         && apt-get -y install $JRE_PACKAGE_NAME \
+         && apt-get -y --purge autoremove \
+         && apt-get autoclean \
+         && apt-get clean \
+         && rm -rf /var/lib/apt/lists/*
 
 COPY --from=pulsar --chown=$UID:$GID /pulsar/conf /pulsar/conf
 COPY --from=pulsar --chown=$UID:$GID /pulsar/bin /pulsar/bin


### PR DESCRIPTION
Fixes https://github.com/streamnative/function-mesh/issues/468

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Different Pulsar version uses different JDK version when compile, as the result, the function runner images should use the same version as the Pulsar uses.

Pulsar 2.11 uses JDK 17, Pulsar 2.10 uses JDK 11, and old versions uses JDK8.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

