### PR TITLE
503: temporarily fix the protobuf conflict in run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	ENABLE_WEBHOOKS=false go run ./main.go
+	ENABLE_WEBHOOKS=false GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests kustomize crd


### PR DESCRIPTION

### Fixes
Fixes #503 

### Motivation

This is a temporary solution to make the `run` command not fail due to the conflict. An ideal solution would be to downgrade the dependency. 

### Modifications

Add a flag when running the go command

### Documentation

No doc update required.


