### PR TITLE
validate the init container with legacy auth & tls config

### DIFF
--- a/.ci/tests/integration-oauth2/e2e.yaml
+++ b/.ci/tests/integration-oauth2/e2e.yaml
@@ -99,11 +99,11 @@ verify:
     # the interval between two attempts, e.g. 10s, 1m.
     interval: 10s
   cases:
-    - query: bash .ci/tests/integration-oauth2/cases/java-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/java-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/java-download-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/java-download-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/py-download-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/py-download-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
       expected: expected.data.yaml

--- a/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
+++ b/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
@@ -99,11 +99,11 @@ verify:
     # the interval between two attempts, e.g. 10s, 1m.
     interval: 10s
   cases:
-    - query: bash .ci/tests/integration-oauth2/cases/java-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/java-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/java-download-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/java-download-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/py-download-function/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/py-download-function/verify.sh
       expected: expected.data.yaml
-    - query: bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
+    - query: timeout 5m bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
       expected: expected.data.yaml

--- a/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
+++ b/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
@@ -105,5 +105,5 @@ verify:
       expected: expected.data.yaml
     - query: bash .ci/tests/integration-oauth2/cases/py-download-function/verify.sh
       expected: expected.data.yaml
-#    - query: bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
-#      expected: expected.data.yaml
+    - query: bash .ci/tests/integration-oauth2/cases/py-download-function-legacy/verify.sh
+      expected: expected.data.yaml

--- a/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
+++ b/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
@@ -95,7 +95,7 @@ verify:
   # verify with retry strategy
   retry:
     # max retry count
-    count: 10
+    count: 2
     # the interval between two attempts, e.g. 10s, 1m.
     interval: 10s
   cases:

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -499,16 +499,11 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 		}...)
 	} else if authProvided {
 		args = []string{
-			"(",
-			PulsarctlExecutableFile,
-			"context",
-			"set",
-			"downloader",
+			"( " + PulsarctlExecutableFile,
+			"oauth2",
+			"activate",
 			"--auth-params",
 			"$clientAuthenticationParameters || true",
-			") && ( " + PulsarctlExecutableFile,
-			"oauth2",
-			"activate || true",
 			") &&",
 			PulsarctlExecutableFile,
 			"--auth-plugin",

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -237,7 +237,7 @@ func MakeStatefulSet(objectMeta *metav1.ObjectMeta, replicas *int32, downloaderI
 	container *corev1.Container,
 	volumes []corev1.Volume, labels map[string]string, policy v1alpha1.PodPolicy, pulsar v1alpha1.PulsarMessaging,
 	javaRuntime *v1alpha1.JavaRuntime, pythonRuntime *v1alpha1.PythonRuntime,
-	goRuntime *v1alpha1.GoRuntime) *appsv1.StatefulSet {
+	goRuntime *v1alpha1.GoRuntime, definedVolumeMounts []corev1.VolumeMount) *appsv1.StatefulSet {
 
 	volumeMounts := generateDownloaderVolumeMountsForDownloader(javaRuntime, pythonRuntime, goRuntime)
 	var downloaderContainer *corev1.Container
@@ -251,6 +251,8 @@ func MakeStatefulSet(objectMeta *metav1.ObjectMeta, replicas *int32, downloaderI
 		if !reflect.ValueOf(pulsar.TLSConfig).IsNil() && pulsar.TLSConfig.HasSecretVolume() {
 			volumeMounts = append(volumeMounts, generateVolumeMountFromTLSConfig(pulsar.TLSConfig))
 		}
+
+		volumeMounts = append(volumeMounts, definedVolumeMounts...)
 
 		var downloadPath, componentPackage string
 		if javaRuntime != nil {

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -498,6 +498,16 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 	} else if authProvided {
 		args = []string{
 			PulsarctlExecutableFile,
+			"context",
+			"set",
+			"downloader",
+			"--auth-params",
+			"$clientAuthenticationParameters || true",
+			"&& " + PulsarctlExecutableFile,
+			"oauth2",
+			"activate || true",
+			"&& ",
+			PulsarctlExecutableFile,
 			"--auth-plugin",
 			"$clientAuthenticationPlugin",
 			"--auth-params",

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -497,16 +497,17 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 		}...)
 	} else if authProvided {
 		args = []string{
+			"(",
 			PulsarctlExecutableFile,
 			"context",
 			"set",
 			"downloader",
 			"--auth-params",
 			"$clientAuthenticationParameters || true",
-			"&& " + PulsarctlExecutableFile,
+			") && ( " + PulsarctlExecutableFile,
 			"oauth2",
 			"activate || true",
-			"&& ",
+			") && ( ",
 			PulsarctlExecutableFile,
 			"--auth-plugin",
 			"$clientAuthenticationPlugin",
@@ -514,6 +515,7 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 			"$clientAuthenticationParameters",
 			"--admin-service-url",
 			"$webServiceURL",
+			")",
 		}
 	} else {
 		args = []string{

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -507,7 +507,7 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 			") && ( " + PulsarctlExecutableFile,
 			"oauth2",
 			"activate || true",
-			") && ( ",
+			") &&",
 			PulsarctlExecutableFile,
 			"--auth-plugin",
 			"$clientAuthenticationPlugin",
@@ -515,7 +515,6 @@ func getDownloadCommand(downloadPath, componentPackage string, tlsProvided, auth
 			"$clientAuthenticationParameters",
 			"--admin-service-url",
 			"$webServiceURL",
-			")",
 		}
 	} else {
 		args = []string{

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -56,7 +56,8 @@ func MakeFunctionStatefulSet(function *v1alpha1.Function) *appsv1.StatefulSet {
 	objectMeta := MakeFunctionObjectMeta(function)
 	return MakeStatefulSet(objectMeta, function.Spec.Replicas, function.Spec.DownloaderImage,
 		MakeFunctionContainer(function), makeFunctionVolumes(function), makeFunctionLabels(function), function.Spec.Pod,
-		*function.Spec.Pulsar, function.Spec.Java, function.Spec.Python, function.Spec.Golang)
+		*function.Spec.Pulsar, function.Spec.Java, function.Spec.Python, function.Spec.Golang,
+		function.Spec.VolumeMounts)
 }
 
 func MakeFunctionObjectMeta(function *v1alpha1.Function) *metav1.ObjectMeta {
@@ -139,7 +140,8 @@ func makeFunctionCommand(function *v1alpha1.Function) []string {
 				generateJavaLogConfigCommand(function.Spec.Java),
 				parseJavaLogLevel(function.Spec.Java),
 				generateFunctionDetailsInJSON(function),
-				getDecimalSIMemory(spec.Resources.Requests.Memory()), spec.Java.ExtraDependenciesDir, string(function.UID),
+				getDecimalSIMemory(spec.Resources.Requests.Memory()), spec.Java.ExtraDependenciesDir,
+				string(function.UID),
 				spec.Java.JavaOpts, spec.Pulsar.AuthSecret != "", spec.Pulsar.TLSSecret != "", function.Spec.SecretsMap,
 				function.Spec.StateConfig, function.Spec.Pulsar.TLSConfig, function.Spec.Pulsar.AuthConfig)
 		}

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -52,7 +52,7 @@ func MakeSinkStatefulSet(sink *v1alpha1.Sink) *appsv1.StatefulSet {
 	objectMeta := MakeSinkObjectMeta(sink)
 	return MakeStatefulSet(objectMeta, sink.Spec.Replicas, sink.Spec.DownloaderImage, MakeSinkContainer(sink),
 		makeSinkVolumes(sink), MakeSinkLabels(sink), sink.Spec.Pod, *sink.Spec.Pulsar,
-		sink.Spec.Java, sink.Spec.Python, sink.Spec.Golang)
+		sink.Spec.Java, sink.Spec.Python, sink.Spec.Golang, sink.Spec.VolumeMounts)
 }
 
 func MakeSinkServiceName(sink *v1alpha1.Sink) string {

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -52,7 +52,7 @@ func MakeSourceStatefulSet(source *v1alpha1.Source) *appsv1.StatefulSet {
 	objectMeta := MakeSourceObjectMeta(source)
 	return MakeStatefulSet(objectMeta, source.Spec.Replicas, source.Spec.DownloaderImage, MakeSourceContainer(source),
 		makeSourceVolumes(source), makeSourceLabels(source), source.Spec.Pod, *source.Spec.Pulsar,
-		source.Spec.Java, source.Spec.Python, source.Spec.Golang)
+		source.Spec.Java, source.Spec.Python, source.Spec.Golang, source.Spec.VolumeMounts)
 }
 
 func MakeSourceObjectMeta(source *v1alpha1.Source) *metav1.ObjectMeta {


### PR DESCRIPTION

Fixes #508

### Motivation

use the latest release of https://github.com/streamnative/pulsarctl/releases/tag/v2.10.2.1 to validate the legacy auth & tls config in the init container.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

