### PR TITLE
Update the FunctionMesh config example to use Docker images

### DIFF
--- a/config/samples/compute_v1alpha1_functionmesh.yaml
+++ b/config/samples/compute_v1alpha1_functionmesh.yaml
@@ -6,6 +6,7 @@ spec:
   functions:
     - name: ex1
       className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+      image: streamnative/pulsar-functions-java-sample:2.9.2.23
       replicas: 1
       maxReplicas: 1
       logTopic: persistent://public/default/logging-function-log
@@ -19,8 +20,10 @@ spec:
       pulsar:
         pulsarConfig: "mesh-test-pulsar"
       java:
-        jar: pulsar-functions-api-examples.jar
-        jarLocation: public/default/nlu-test-functionmesh-ex1
+        jar: /pulsar/examples/api-examples.jar
+    # use "" to read jar from local file system
+        jarLocation: ""
+        extraDependenciesDir: random-dir/
       # following value must be provided if no auto-filling is enabled
       forwardSourceMessageProperty: true
       autoAck: true
@@ -34,6 +37,7 @@ spec:
       clusterName: test-pulsar
     - name: ex2
       className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+      image: streamnative/pulsar-functions-java-sample:2.9.2.23
       replicas: 1
       maxReplicas: 1
       logTopic: persistent://public/default/logging-function-logs
@@ -47,8 +51,10 @@ spec:
       pulsar:
         pulsarConfig: "mesh-test-pulsar"
       java:
-        jar: pulsar-functions-api-examples.jar
-        jarLocation: public/default/nlu-test-functionmesh-ex2
+        jar: /pulsar/examples/api-examples.jar
+    # use "" to read jar from local file system
+        jarLocation: ""
+        extraDependenciesDir: random-dir/
       # following value must be provided if no auto-filling is enabled
       forwardSourceMessageProperty: true
       autoAck: true

--- a/config/samples/compute_v1alpha1_functionmesh.yaml
+++ b/config/samples/compute_v1alpha1_functionmesh.yaml
@@ -21,7 +21,7 @@ spec:
         pulsarConfig: "mesh-test-pulsar"
       java:
         jar: /pulsar/examples/api-examples.jar
-    # use "" to read jar from local file system
+    # use "" to read jar from the container's file system
         jarLocation: ""
         extraDependenciesDir: random-dir/
       # following value must be provided if no auto-filling is enabled

--- a/config/samples/compute_v1alpha1_functionmesh.yaml
+++ b/config/samples/compute_v1alpha1_functionmesh.yaml
@@ -52,7 +52,7 @@ spec:
         pulsarConfig: "mesh-test-pulsar"
       java:
         jar: /pulsar/examples/api-examples.jar
-    # use "" to read jar from local file system
+    # use "" to read jar from the container's file system
         jarLocation: ""
         extraDependenciesDir: random-dir/
       # following value must be provided if no auto-filling is enabled


### PR DESCRIPTION



<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

When using the existing example of compute_v1alpha1_functionmesh.yaml, it complains about the format of jarLocation and uploading jar package requires additional steps. 

### Modifications

Inspired by #542 the Docker image is used here for the Function which eliminates the steps to handle package uploading to make the onboarding easier.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  The example self explains.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

