### PR TITLE
only trigger release action on v* tags and ignore function-mesh-* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   upload:
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Upload Release files
     runs-on: ubuntu-latest
     steps:
@@ -95,6 +96,7 @@ jobs:
           overwrite: true
 
   openshift:
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Upload Release files
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes https://github.com/streamnative/function-mesh/issues/626

### Motivation

The release of helm charts is handled by streamnative-ci, and the release action should not be triggered.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

