### PR TITLE
Do not do clean up resources managed by function-mesh-worker-service

### DIFF
--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -259,6 +259,16 @@ func (r *SinkReconciler) ApplySinkVPA(ctx context.Context, sink *v1alpha1.Sink) 
 
 func (r *SinkReconciler) ApplySinkCleanUpJob(ctx context.Context, sink *v1alpha1.Sink) error {
 	if !spec.NeedCleanup(sink) {
+		desiredJob := spec.MakeSinkCleanUpJob(sink)
+		if err := r.Delete(ctx, desiredJob); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			r.Log.Error(err, "error delete cleanup job for sink",
+				"namespace", sink.Namespace, "name", sink.Name,
+				"job name", desiredJob.Name)
+			return err
+		}
 		return nil
 	}
 	hasCleanupFinalizer := containsCleanupFinalizer(sink.ObjectMeta.Finalizers)

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -259,6 +259,16 @@ func (r *SourceReconciler) ApplySourceVPA(ctx context.Context, source *v1alpha1.
 
 func (r *SourceReconciler) ApplySourceCleanUpJob(ctx context.Context, source *v1alpha1.Source) error {
 	if !spec.NeedCleanup(source) {
+		desiredJob := spec.MakeSourceCleanUpJob(source)
+		if err := r.Delete(ctx, desiredJob); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			r.Log.Error(err, "error delete cleanup job for source",
+				"namespace", source.Namespace, "name", source.Name,
+				"job name", desiredJob.Name)
+			return err
+		}
 		return nil
 	}
 	hasCleanupFinalizer := containsCleanupFinalizer(source.ObjectMeta.Finalizers)

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -91,6 +91,10 @@ const (
 	AnnotationManaged          = "compute.functionmesh.io/managed"
 	AnnotationNeedCleanup      = "compute.functionmesh.io/need-cleanup"
 
+	// if labels contains below, we think it comes from function-mesh-worker-service
+	LabelPulsarCluster           = "compute.functionmesh.io/pulsar-cluster"
+	LabelPulsarClusterDeprecated = "pulsar-cluster"
+
 	EnvGoFunctionConfigs = "GO_FUNCTION_CONF"
 
 	DefaultRunnerUserID  int64 = 10000
@@ -229,6 +233,16 @@ func IsManaged(object metav1.Object) bool {
 }
 
 func NeedCleanup(object metav1.Object) bool {
+	// don't cleanup if it's managed by function-mesh-worker-service
+	_, exists := object.GetLabels()[LabelPulsarCluster]
+	if exists {
+		return false
+	}
+	_, exists = object.GetLabels()[LabelPulsarClusterDeprecated]
+	if exists {
+		return false
+	}
+
 	needCleanup, exists := object.GetAnnotations()[AnnotationNeedCleanup]
 	return !exists || needCleanup != "false"
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

existing resources managed by function-mesh-worker-service also start a clean-up job since they may be created by old function-mesh-worker-service and do not have the `compute.functionmesh.io/need-cleanup` annotation, we should avoid that

### Modifications

Do not clean up for resources managed by function-mesh-worker-service

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

