### PR TITLE
fix e2e pulsar install

### DIFF
--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -89,7 +89,9 @@ function ci::install_pulsar_charts() {
     cp ${values} pulsar-charts/charts/pulsar/mini_values.yaml
     cd pulsar-charts
     ./scripts/pulsar/prepare_helm_release.sh -n default -k sn-platform -c
-    helm repo add loki https://grafana.github.io/loki/charts
+    helm repo add grafana https://grafana.github.io/helm-charts
+    helm repo update
+    yq -i '.dependencies[0].repository = "https://grafana.github.io/helm-charts"' charts/pulsar/requirements.yaml
     helm dependency update charts/pulsar
     ${HELM} install sn-platform --set initialize=true --values charts/pulsar/mini_values.yaml charts/pulsar --debug
 

--- a/.ci/tests/integration-oauth2/e2e.yaml
+++ b/.ci/tests/integration-oauth2/e2e.yaml
@@ -36,7 +36,9 @@ setup:
         git clone https://github.com/streamnative/charts.git pulsar-charts
         cd pulsar-charts/
         ./scripts/pulsar/prepare_helm_release.sh -n default -k ${PULSAR_RELEASE_NAME} -c
-        helm repo add loki https://grafana.github.io/loki/charts
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+        yq -i '.dependencies[0].repository = "https://grafana.github.io/helm-charts"' charts/pulsar/requirements.yaml
         helm dependency update charts/pulsar
         helm install ${PULSAR_RELEASE_NAME} --set initialize=true --values ../.ci/clusters/values_skywalking_e2e_cluster_with_oauth.yaml charts/pulsar
 

--- a/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
+++ b/.ci/tests/integration-oauth2/e2e_with_downloader.yaml
@@ -36,7 +36,9 @@ setup:
         git clone https://github.com/streamnative/charts.git pulsar-charts
         cd pulsar-charts/
         ./scripts/pulsar/prepare_helm_release.sh -n default -k ${PULSAR_RELEASE_NAME} -c
-        helm repo add loki https://grafana.github.io/loki/charts
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+        yq -i '.dependencies[0].repository = "https://grafana.github.io/helm-charts"' charts/pulsar/requirements.yaml
         helm dependency update charts/pulsar
         helm install ${PULSAR_RELEASE_NAME} --set initialize=true --values ../.ci/clusters/values_skywalking_e2e_cluster_with_oauth.yaml charts/pulsar
 

--- a/.ci/tests/integration/e2e.yaml
+++ b/.ci/tests/integration/e2e.yaml
@@ -42,7 +42,9 @@ setup:
         git clone https://github.com/streamnative/charts.git pulsar-charts
         cd pulsar-charts/
         ./scripts/pulsar/prepare_helm_release.sh -n default -k ${PULSAR_RELEASE_NAME} -c
-        helm repo add loki https://grafana.github.io/loki/charts
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+        yq -i '.dependencies[0].repository = "https://grafana.github.io/helm-charts"' charts/pulsar/requirements.yaml
         helm dependency update charts/pulsar
         helm install ${PULSAR_RELEASE_NAME} --set initialize=true --values ../.ci/clusters/values_skywalking_e2e_cluster.yaml charts/pulsar
 

--- a/.ci/tests/integration/e2e_with_tls.yaml
+++ b/.ci/tests/integration/e2e_with_tls.yaml
@@ -31,7 +31,9 @@ setup:
         git clone https://github.com/streamnative/charts.git pulsar-charts
         cd pulsar-charts/
         ./scripts/pulsar/prepare_helm_release.sh -n default -k ${PULSAR_RELEASE_NAME} -c
-        helm repo add loki https://grafana.github.io/loki/charts
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+        yq -i '.dependencies[0].repository = "https://grafana.github.io/helm-charts"' charts/pulsar/requirements.yaml
         helm dependency update charts/pulsar
         helm install ${PULSAR_RELEASE_NAME} --set initialize=true --values ../.ci/clusters/values_skywalking_e2e_cluster_with_tls.yaml charts/pulsar
 


### PR DESCRIPTION
### Motivation

fix

```
+ helm repo add loki https://grafana.github.io/loki/charts
Error: looks like "https://grafana.github.io/loki/charts" is not a valid chart repository or cannot be reached: failed to fetch https://grafana.github.io/loki/charts/index.yaml : 404 Not Found
```

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

