### PR TITLE
support YAML config for java runtime, support log format json for java and python

### DIFF
--- a/.ci/tests/integration/cases/java-log-format-json/manifests.yaml
+++ b/.ci/tests/integration/cases/java-log-format-json/manifests.yaml
@@ -1,0 +1,70 @@
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: java-log-level
+  namespace: default
+spec:
+  image: streamnative/pulsar-functions-java-sample:2.9.2.23
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  forwardSourceMessageProperty: true
+  maxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 5
+  logTopic: persistent://public/default/logging-function-logs
+  input:
+    topics:
+    - persistent://public/default/input-java-log-level-topic
+    typeClassName: java.lang.String
+  output:
+    topic: persistent://public/default/output-java-log-level-topic
+    typeClassName: java.lang.String
+  resources:
+    requests:
+      cpu: 50m
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1.1G
+  # each secret will be loaded ad an env variable from the `path` secret with the `key` in that secret in the name of `name`
+  secretsMap:
+    "name":
+        path: "test-secret"
+        key: "username"
+    "pwd":
+        path: "test-secret"
+        key: "password"
+  pulsar:
+    pulsarConfig: "test-pulsar"
+    tlsConfig:
+      enabled: false
+      allowInsecure: false
+      hostnameVerification: true
+      certSecretName: sn-platform-tls-broker
+      certSecretKey: ""
+    #authConfig: "test-auth"
+  java:
+    log:
+      level: "debug"
+      javaLog4JConfigFileType: "yaml"
+      format: "json"
+    jar: /pulsar/examples/api-examples.jar
+  # to be delete & use admission hook
+  clusterName: test
+  autoAck: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-pulsar
+data:
+  webServiceURL: http://sn-platform-pulsar-broker.default.svc.cluster.local:8080
+  brokerServiceURL: pulsar://sn-platform-pulsar-broker.default.svc.cluster.local:6650
+---
+apiVersion: v1
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque

--- a/.ci/tests/integration/cases/java-log-format-json/verify.sh
+++ b/.ci/tests/integration/cases/java-log-format-json/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+E2E_DIR=$(dirname "$0")
+BASE_DIR=$(cd "${E2E_DIR}"/../../../../..;pwd)
+PULSAR_NAMESPACE=${PULSAR_NAMESPACE:-"default"}
+PULSAR_RELEASE_NAME=${PULSAR_RELEASE_NAME:-"sn-platform"}
+E2E_KUBECONFIG=${E2E_KUBECONFIG:-"/tmp/e2e-k8s.config"}
+
+source "${BASE_DIR}"/.ci/helm.sh
+
+if [ ! "$KUBECONFIG" ]; then
+  export KUBECONFIG=${E2E_KUBECONFIG}
+fi
+
+manifests_file="${BASE_DIR}"/.ci/tests/integration/cases/java-log-format-json/manifests.yaml
+
+kubectl apply -f "${manifests_file}" > /dev/null 2>&1
+
+verify_fm_result=$(ci::verify_function_mesh java-log-format-json 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_fm_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_java_result=$(NAMESPACE=${PULSAR_NAMESPACE} CLUSTER=${PULSAR_RELEASE_NAME} ci::verify_exclamation_function "persistent://public/default/input-java-log-format-json-topic" "persistent://public/default/output-java-log-format-json-topic" "test-message" "test-message!" 10 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_java_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_log_level_result=$(kubectl logs -l compute.functionmesh.io/name=java-log-format-json --tail=-1 | grep "Got result: object:" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "e2e-test: ok" | yq eval -
+else
+  echo "$verify_log_level_result"
+fi
+kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true

--- a/.ci/tests/integration/cases/java-log-yaml/manifests.yaml
+++ b/.ci/tests/integration/cases/java-log-yaml/manifests.yaml
@@ -1,0 +1,69 @@
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: java-log-level
+  namespace: default
+spec:
+  image: streamnative/pulsar-functions-java-sample:2.9.2.23
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  forwardSourceMessageProperty: true
+  maxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 5
+  logTopic: persistent://public/default/logging-function-logs
+  input:
+    topics:
+    - persistent://public/default/input-java-log-level-topic
+    typeClassName: java.lang.String
+  output:
+    topic: persistent://public/default/output-java-log-level-topic
+    typeClassName: java.lang.String
+  resources:
+    requests:
+      cpu: 50m
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1.1G
+  # each secret will be loaded ad an env variable from the `path` secret with the `key` in that secret in the name of `name`
+  secretsMap:
+    "name":
+        path: "test-secret"
+        key: "username"
+    "pwd":
+        path: "test-secret"
+        key: "password"
+  pulsar:
+    pulsarConfig: "test-pulsar"
+    tlsConfig:
+      enabled: false
+      allowInsecure: false
+      hostnameVerification: true
+      certSecretName: sn-platform-tls-broker
+      certSecretKey: ""
+    #authConfig: "test-auth"
+  java:
+    log:
+      level: "debug"
+      javaLog4JConfigFileType: "yaml"
+    jar: /pulsar/examples/api-examples.jar
+  # to be delete & use admission hook
+  clusterName: test
+  autoAck: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-pulsar
+data:
+  webServiceURL: http://sn-platform-pulsar-broker.default.svc.cluster.local:8080
+  brokerServiceURL: pulsar://sn-platform-pulsar-broker.default.svc.cluster.local:6650
+---
+apiVersion: v1
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque

--- a/.ci/tests/integration/cases/java-log-yaml/verify.sh
+++ b/.ci/tests/integration/cases/java-log-yaml/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+E2E_DIR=$(dirname "$0")
+BASE_DIR=$(cd "${E2E_DIR}"/../../../../..;pwd)
+PULSAR_NAMESPACE=${PULSAR_NAMESPACE:-"default"}
+PULSAR_RELEASE_NAME=${PULSAR_RELEASE_NAME:-"sn-platform"}
+E2E_KUBECONFIG=${E2E_KUBECONFIG:-"/tmp/e2e-k8s.config"}
+
+source "${BASE_DIR}"/.ci/helm.sh
+
+if [ ! "$KUBECONFIG" ]; then
+  export KUBECONFIG=${E2E_KUBECONFIG}
+fi
+
+manifests_file="${BASE_DIR}"/.ci/tests/integration/cases/java-log-yaml/manifests.yaml
+
+kubectl apply -f "${manifests_file}" > /dev/null 2>&1
+
+verify_fm_result=$(ci::verify_function_mesh java-log-yaml 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_fm_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_java_result=$(NAMESPACE=${PULSAR_NAMESPACE} CLUSTER=${PULSAR_RELEASE_NAME} ci::verify_exclamation_function "persistent://public/default/input-java-log-yaml-topic" "persistent://public/default/output-java-log-yaml-topic" "test-message" "test-message!" 10 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_java_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_log_level_result=$(kubectl logs -l compute.functionmesh.io/name=java-log-yaml --tail=-1 | grep "Got result: object:" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "e2e-test: ok" | yq eval -
+else
+  echo "$verify_log_level_result"
+fi
+kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true

--- a/.ci/tests/integration/cases/python-log-format-json/manifests.yaml
+++ b/.ci/tests/integration/cases/python-log-format-json/manifests.yaml
@@ -1,0 +1,61 @@
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: python-log-level
+  namespace: default
+spec:
+  image: streamnative/pulsar-functions-python-sample:2.9.2.23
+  className: exclamation_function.ExclamationFunction
+  forwardSourceMessageProperty: true
+  maxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 1
+  logTopic: persistent://public/default/py-function-logs
+  input:
+    topics:
+      - persistent://public/default/input-python-log-level-topic
+  output:
+    topic: persistent://public/default/output-python-log-level-topic
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1.1G
+  # each secret will be loaded ad an env variable from the `path` secret with the `key` in that secret in the name of `name`
+  secretsMap:
+    "name":
+      path: "test-py-secret"
+      key: "username"
+    "pwd":
+      path: "test-py-secret"
+      key: "password"
+  pulsar:
+    pulsarConfig: "test-py-pulsar"
+    #authConfig: "test-auth"
+  python:
+    log:
+      level: "debug"
+      format: "json"
+    py: /pulsar/examples/python-examples/exclamation_function.py
+  # to be delete & use admission hook
+  clusterName: test
+  autoAck: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-py-pulsar
+data:
+  webServiceURL: http://sn-platform-pulsar-broker.default.svc.cluster.local:8080
+  brokerServiceURL: pulsar://sn-platform-pulsar-broker.default.svc.cluster.local:6650
+---
+apiVersion: v1
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+kind: Secret
+metadata:
+  name: test-py-secret
+type: Opaque

--- a/.ci/tests/integration/cases/python-log-format-json/verify.sh
+++ b/.ci/tests/integration/cases/python-log-format-json/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+E2E_DIR=$(dirname "$0")
+BASE_DIR=$(cd "${E2E_DIR}"/../../../../..;pwd)
+PULSAR_NAMESPACE=${PULSAR_NAMESPACE:-"default"}
+PULSAR_RELEASE_NAME=${PULSAR_RELEASE_NAME:-"sn-platform"}
+E2E_KUBECONFIG=${E2E_KUBECONFIG:-"/tmp/e2e-k8s.config"}
+
+source "${BASE_DIR}"/.ci/helm.sh
+
+if [ ! "$KUBECONFIG" ]; then
+  export KUBECONFIG=${E2E_KUBECONFIG}
+fi
+
+manifests_file="${BASE_DIR}"/.ci/tests/integration/cases/python-log-format-json/manifests.yaml
+
+kubectl apply -f "${manifests_file}" > /dev/null 2>&1
+
+verify_fm_result=$(ci::verify_function_mesh python-log-format-json 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_fm_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_python_result=$(NAMESPACE=${PULSAR_NAMESPACE} CLUSTER=${PULSAR_RELEASE_NAME} ci::verify_exclamation_function "persistent://public/default/input-python-log-format-json-topic" "persistent://public/default/output-python-log-format-json-topic" "test-message" "test-message!" 10 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$verify_python_result"
+  kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true
+  exit 1
+fi
+
+verify_log_level_result=$(kubectl logs -l compute.functionmesh.io/name=python-log-format-json --tail=-1 | grep "Got a message from topic" 2>&1)
+if [ $? -eq 0 ]; then
+  echo "e2e-test: ok" | yq eval -
+else
+  echo "$verify_log_level_result"
+fi
+kubectl delete -f "${manifests_file}" > /dev/null 2>&1 || true

--- a/api/compute/v1alpha1/common.go
+++ b/api/compute/v1alpha1/common.go
@@ -487,10 +487,28 @@ const (
 // +kubebuilder:validation:Enum=TimedPolicyWithDaily;TimedPolicyWithWeekly;TimedPolicyWithMonthly;SizedPolicyWith10MB;SizedPolicyWith50MB;SizedPolicyWith100MB
 type TriggeringPolicy string
 
+// +kubebuilder:validation:Enum=json;text
+type FormatType string
+
+const (
+	JSON FormatType = "json"
+	TEXT FormatType = "text"
+)
+
+// +kubebuilder:validation:Enum=yaml;xml;ini
+type JavaLog4JConfigFileType string
+
+const (
+	XML  JavaLog4JConfigFileType = "xml"
+	YAML JavaLog4JConfigFileType = "yaml"
+)
+
 type RuntimeLogConfig struct {
-	Level        LogLevel          `json:"level,omitempty"`
-	RotatePolicy *TriggeringPolicy `json:"rotatePolicy,omitempty"`
-	LogConfig    *LogConfig        `json:"logConfig,omitempty"`
+	Level                   LogLevel                 `json:"level,omitempty"`
+	RotatePolicy            *TriggeringPolicy        `json:"rotatePolicy,omitempty"`
+	Format                  *FormatType              `json:"format,omitempty"`
+	LogConfig               *LogConfig               `json:"logConfig,omitempty"`
+	JavaLog4JConfigFileType *JavaLog4JConfigFileType `json:"javaLog4JConfigFileType,omitempty"`
 }
 
 type LogConfig struct {

--- a/api/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/api/compute/v1alpha1/zz_generated.deepcopy.go
@@ -1109,9 +1109,19 @@ func (in *RuntimeLogConfig) DeepCopyInto(out *RuntimeLogConfig) {
 		*out = new(TriggeringPolicy)
 		**out = **in
 	}
+	if in.Format != nil {
+		in, out := &in.Format, &out.Format
+		*out = new(FormatType)
+		**out = **in
+	}
 	if in.LogConfig != nil {
 		in, out := &in.LogConfig, &out.LogConfig
 		*out = new(LogConfig)
+		**out = **in
+	}
+	if in.JavaLog4JConfigFileType != nil {
+		in, out := &in.JavaLog4JConfigFileType, &out.JavaLog4JConfigFileType
+		*out = new(JavaLog4JConfigFileType)
 		**out = **in
 	}
 }

--- a/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-functionmeshes.yaml
+++ b/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-functionmeshes.yaml
@@ -56,6 +56,17 @@ spec:
                             type: string
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -185,6 +196,17 @@ spec:
                             type: array
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -3237,6 +3259,17 @@ spec:
                         properties:
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -3584,6 +3617,17 @@ spec:
                             type: string
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -3713,6 +3757,17 @@ spec:
                             type: array
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -6689,6 +6744,17 @@ spec:
                         properties:
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -6857,6 +6923,17 @@ spec:
                             type: string
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -6914,6 +6991,17 @@ spec:
                             type: array
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"
@@ -9951,6 +10039,17 @@ spec:
                         properties:
                           log:
                             properties:
+                              format:
+                                enum:
+                                  - json
+                                  - text
+                                type: string
+                              javaLog4JConfigFileType:
+                                enum:
+                                  - yaml
+                                  - xml
+                                  - ini
+                                type: string
                               level:
                                 enum:
                                   - "off"

--- a/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-functions.yaml
+++ b/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-functions.yaml
@@ -75,6 +75,17 @@ spec:
                       type: string
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -204,6 +215,17 @@ spec:
                       type: array
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -3256,6 +3278,17 @@ spec:
                   properties:
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"

--- a/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-sinks.yaml
+++ b/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-sinks.yaml
@@ -70,6 +70,17 @@ spec:
                       type: string
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -199,6 +210,17 @@ spec:
                       type: array
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -3175,6 +3197,17 @@ spec:
                   properties:
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"

--- a/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-sources.yaml
+++ b/charts/function-mesh-operator/charts/admission-webhook/templates/crd-compute.functionmesh.io-sources.yaml
@@ -76,6 +76,17 @@ spec:
                       type: string
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -133,6 +144,17 @@ spec:
                       type: array
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"
@@ -3170,6 +3192,17 @@ spec:
                   properties:
                     log:
                       properties:
+                        format:
+                          enum:
+                            - json
+                            - text
+                          type: string
+                        javaLog4JConfigFileType:
+                          enum:
+                            - yaml
+                            - xml
+                            - ini
+                          type: string
                         level:
                           enum:
                             - "off"

--- a/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functionmeshes.yaml
@@ -57,6 +57,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -186,6 +197,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -3238,6 +3260,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -3585,6 +3618,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -3714,6 +3758,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6690,6 +6745,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6858,6 +6924,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6915,6 +6992,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -9952,6 +10040,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"

--- a/config/crd/bases/compute.functionmesh.io_functions.yaml
+++ b/config/crd/bases/compute.functionmesh.io_functions.yaml
@@ -54,6 +54,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -183,6 +194,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -3235,6 +3257,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"

--- a/config/crd/bases/compute.functionmesh.io_sinks.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sinks.yaml
@@ -49,6 +49,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -178,6 +189,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -3154,6 +3176,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"

--- a/config/crd/bases/compute.functionmesh.io_sources.yaml
+++ b/config/crd/bases/compute.functionmesh.io_sources.yaml
@@ -55,6 +55,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -112,6 +123,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -3149,6 +3171,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -716,33 +716,31 @@ func generateJavaLogConfigCommand(runtime *v1alpha1.JavaRuntime) string {
 	if runtime == nil || (runtime.Log != nil && runtime.Log.LogConfig != nil) {
 		return ""
 	}
-	if runtime != nil && runtime.Log != nil {
-		configFileType := v1alpha1.XML
-		if runtime.Log.JavaLog4JConfigFileType != nil {
-			configFileType = *runtime.Log.JavaLog4JConfigFileType
-		}
-		switch configFileType {
-		case v1alpha1.XML:
-			{
-				if log4jXML, err := renderJavaInstanceLog4jXMLTemplate(runtime); err == nil {
-					generateConfigFileCommand := []string{
-						"mkdir", "-p", JavaLogConfigDirectory, "&&",
-						"echo", fmt.Sprintf("\"%s\"", log4jXML), ">", DefaultJavaLogConfigPath,
-						"&& ",
-					}
-					return strings.Join(generateConfigFileCommand, " ")
+	configFileType := v1alpha1.XML
+	if runtime != nil && runtime.Log != nil && runtime.Log.JavaLog4JConfigFileType != nil {
+		configFileType = *runtime.Log.JavaLog4JConfigFileType
+	}
+	switch configFileType {
+	case v1alpha1.XML:
+		{
+			if log4jXML, err := renderJavaInstanceLog4jXMLTemplate(runtime); err == nil {
+				generateConfigFileCommand := []string{
+					"mkdir", "-p", JavaLogConfigDirectory, "&&",
+					"echo", fmt.Sprintf("\"%s\"", log4jXML), ">", DefaultJavaLogConfigPath,
+					"&& ",
 				}
+				return strings.Join(generateConfigFileCommand, " ")
 			}
-		case v1alpha1.YAML:
-			{
-				if log4jYAML, err := renderJavaInstanceLog4jYAMLTemplate(runtime); err == nil {
-					generateConfigFileCommand := []string{
-						"mkdir", "-p", JavaLogConfigDirectory, "&&",
-						"echo", fmt.Sprintf("\"%s\"", log4jYAML), ">", DefaultJavaLogConfigPathYAML,
-						"&& ",
-					}
-					return strings.Join(generateConfigFileCommand, " ")
+		}
+	case v1alpha1.YAML:
+		{
+			if log4jYAML, err := renderJavaInstanceLog4jYAMLTemplate(runtime); err == nil {
+				generateConfigFileCommand := []string{
+					"mkdir", "-p", JavaLogConfigDirectory, "&&",
+					"echo", fmt.Sprintf("\"%s\"", log4jYAML), ">", DefaultJavaLogConfigPathYAML,
+					"&& ",
 				}
+				return strings.Join(generateConfigFileCommand, " ")
 			}
 		}
 	}

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -20,6 +20,8 @@ package spec
 import (
 	"bytes"
 	"context"
+
+	// used for template
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -1768,7 +1770,7 @@ const (
 func getRuntimeLogConfigNames(java *v1alpha1.JavaRuntime, python *v1alpha1.PythonRuntime,
 	golang *v1alpha1.GoRuntime) map[int32]*v1alpha1.RuntimeLogConfig {
 
-	var configs map[int32]*v1alpha1.RuntimeLogConfig
+	var configs = map[int32]*v1alpha1.RuntimeLogConfig{}
 
 	if java != nil && java.Log != nil && java.Log.LogConfig != nil {
 		configs[javaRuntimeLog] = java.Log

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -120,7 +120,6 @@ func MakeFunctionCleanUpJob(function *v1alpha1.Function) *v1.Job {
 }
 
 func makeFunctionVolumes(function *v1alpha1.Function, authConfig *v1alpha1.AuthConfig) []corev1.Volume {
-
 	return generatePodVolumes(function.Spec.Pod.Volumes,
 		function.Spec.Output.ProducerConf,
 		function.Spec.Input.SourceSpecs,

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -120,6 +120,7 @@ func MakeFunctionCleanUpJob(function *v1alpha1.Function) *v1.Job {
 }
 
 func makeFunctionVolumes(function *v1alpha1.Function, authConfig *v1alpha1.AuthConfig) []corev1.Volume {
+
 	return generatePodVolumes(function.Spec.Pod.Volumes,
 		function.Spec.Output.ProducerConf,
 		function.Spec.Input.SourceSpecs,

--- a/controllers/spec/template/java-runtime-log4j.xml.tmpl
+++ b/controllers/spec/template/java-runtime-log4j.xml.tmpl
@@ -1,0 +1,74 @@
+<Configuration>
+    <name>pulsar-functions-kubernetes-instance</name>
+    <monitorInterval>30</monitorInterval>
+    <Properties>
+        <Property>
+            <name>pulsar.log.level</name>
+            <value>{{ .Level }}</value>
+        </Property>
+        <Property>
+            <name>bk.log.level</name>
+            <value>{{ .Level }}</value>
+        </Property>
+    </Properties>
+    <Appenders>
+        <Console>
+            <name>Console</name>
+            <target>SYSTEM_OUT</target>
+            {{ if .Format | eq "json" }}
+            <JSONLayout>
+                <complete>true</complete>
+                <compact>true</compact>
+                <eventEol>true</eventEol>
+            </JSONLayout>
+            {{ else }}
+            <PatternLayout>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+            </PatternLayout>
+            {{ end }}
+        </Console>
+        {{- if .RollingEnabled }}
+        <RollingRandomAccessFile>
+            <name>RollingRandomAccessFile</name>
+            <fileName>\${sys:pulsar.function.log.dir}/\${sys:pulsar.function.log.file}.log</fileName>
+            <filePattern>\${sys:pulsar.function.log.dir}/\${sys:pulsar.function.log.file}.%d{yyyy-MM-dd-hh-mm}-%i.log.gz</filePattern>
+            <PatternLayout>
+                <Pattern>%d{yyyy-MMM-dd HH:mm:ss a} [%t] %-5level %logger{36} - %msg%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                {{ .Policy }}
+            </Policies>
+            <DefaultRolloverStrategy>
+                <max>5</max>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+       {{- end }}
+    </Appenders>
+    <Loggers>
+        <Logger>
+            <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
+            <level>\${sys:bk.log.level}</level>
+            <additivity>false</additivity>
+            <AppenderRef>
+                <ref>Console</ref>
+            </AppenderRef>
+            {{- if .RollingEnabled }}
+            <AppenderRef>
+                <ref>RollingRandomAccessFile</ref>
+            </AppenderRef>
+            {{- end }}
+        </Logger>
+        <Root>
+            <level>\${sys:pulsar.log.level}</level>
+            <AppenderRef>
+                <ref>Console</ref>
+                <level>\${sys:pulsar.log.level}</level>
+            </AppenderRef>
+            {{- if .RollingEnabled }}
+            <AppenderRef>
+                <ref>RollingRandomAccessFile</ref>
+            </AppenderRef>
+            {{- end }}
+        </Root>
+    </Loggers>
+</Configuration>

--- a/controllers/spec/template/java-runtime-log4j.yaml.tmpl
+++ b/controllers/spec/template/java-runtime-log4j.yaml.tmpl
@@ -1,0 +1,76 @@
+Configuration:
+  name: pulsar-functions-kubernetes-instance
+  monitorInterval: 30
+  Properties:
+    Property:
+    - name: pulsar.log.level
+      value: {{ .Level }}
+    - name: bk.log.level
+      value: {{ .Level }}
+
+  Appenders:
+    Console:
+      name: Console
+      target: SYSTEM_OUT
+      {{ if .Format | eq "json" }}
+      JSONLayout:
+        complete: true
+        compact: true
+        eventEol: true
+      {{ else }}
+      PatternLayout:
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+      {{ end }}
+
+    RollingRandomAccessFile:
+      name: RollingRandomAccessFile
+      fileName: "${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.log"
+      filePattern: "${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.%d{yyyy-MM-dd-hh-mm}-%i.log.gz"
+      PatternLayout:
+        Pattern: "%d{yyyy-MMM-dd HH:mm:ss a} [%t] %-5level %logger{36} - %msg%n"
+      Policies:
+        {{ if .Policy | eq "TimedPolicyWithDaily" }}
+        CronTriggeringPolicy:
+          schedule: "0 0 0 * * ? *"
+        {{ else if .Policy | eq "TimedPolicyWithWeekly"}}
+        CronTriggeringPolicy:
+          schedule: "0 0 0 ? * 1 *"
+        {{ else if .Policy | eq "TimedPolicyWithMonthly"}}
+        CronTriggeringPolicy:
+          schedule: "0 0 0 1 * ? *"
+        {{ else if .Policy | eq "SizedPolicyWith10MB"}}
+        SizeBasedTriggeringPolicy:
+          size: "10MB"
+        {{ else if .Policy | eq "SizedPolicyWith50MB"}}
+        SizeBasedTriggeringPolicy:
+          size: "50MB"
+        {{ else if .Policy | eq "SizedPolicyWith100MB"}}
+        SizeBasedTriggeringPolicy:
+          size: "100MB"
+        {{ else }}
+        TimeBasedTriggeringPolicy:
+          interval: 1
+          modulate: true
+        SizeBasedTriggeringPolicy:
+          size: "10MB"
+        CronTriggeringPolicy:
+          schedule: "0 0 0 * * ?"
+        {{ end }}
+
+      DefaultRolloverStrategy:
+        max: 5
+
+  Loggers:
+    Root:
+      level: "${sys:pulsar.log.level}"
+      AppenderRef:
+        - ref: Console
+          level: "${sys:pulsar.log.level}"
+        - ref: RollingRandomAccessFile
+    Logger:
+      name: org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper
+      level: "${sys:bk.log.level}"
+      additivity: false
+      AppenderRef:
+      - ref: Console
+      - ref: RollingRandomAccessFile

--- a/controllers/spec/template/python-runtime-log-config.ini.tmpl
+++ b/controllers/spec/template/python-runtime-log-config.ini.tmpl
@@ -1,0 +1,36 @@
+[loggers]
+keys=root
+
+[handlers]
+keys={{ .Handlers }}
+
+[formatters]
+{{ if .Format | eq "json" }}
+keys=json
+{{ else }}
+keys=formatter
+{{ end }}
+
+[logger_root]
+level={{ .Level }}
+handlers={{ .Handlers }}
+
+{{- if .RollingEnabled }}
+{{ .Policy }}
+{{- end }}
+
+[handler_stream_handler]
+class=StreamHandler
+level={{ .Level }}
+formatter=formatter
+args=(sys.stdout,)
+
+{{ if .Format | eq "json" }}
+[formatter_json]
+format = %(message)s
+class = pythonjsonlogger.jsonlogger.JsonFormatter
+{{ else }}
+[formatter_formatter]
+format=[%(asctime)s] [%(levelname)s] %(filename)s: %(message)s
+datefmt=%Y-%m-%d %H:%M:%S %z
+{{ end }}

--- a/images/pulsar-functions-python-runner/Dockerfile
+++ b/images/pulsar-functions-python-runner/Dockerfile
@@ -50,3 +50,5 @@ RUN rm -rf /pulsar/instances/python-instance/pulsar/ \
 USER $USER
 # a temp solution from https://github.com/apache/pulsar/pull/15846 to fix python protobuf version error
 RUN pip3 install protobuf==3.20.1 --user
+# to make the python runner could print json logs
+RUN pip3 install python-json-logger --user

--- a/images/pulsar-functions-python-runner/pulsarctl.Dockerfile
+++ b/images/pulsar-functions-python-runner/pulsarctl.Dockerfile
@@ -44,3 +44,5 @@ WORKDIR /pulsar
 USER $USER
 # a temp solution from https://github.com/apache/pulsar/pull/15846 to fix python protobuf version error
 RUN pip3 install protobuf==3.20.1 --user
+# to make the python runner could print json logs
+RUN pip3 install python-json-logger --user

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -172,6 +172,8 @@ spec:
                       type: boolean
                     className:
                       type: string
+                    cleanupImage:
+                      type: string
                     cleanupSubscription:
                       type: boolean
                     clusterName:
@@ -193,6 +195,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -230,6 +243,10 @@ spec:
                       type: object
                     image:
                       type: string
+                    imageHasGet:
+                      type: boolean
+                    imageHasPulsarctl:
+                      type: boolean
                     imagePullPolicy:
                       type: string
                     input:
@@ -318,6 +335,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -383,6 +411,14 @@ spec:
                           properties:
                             batchBuilder:
                               type: string
+                            compressionType:
+                              enum:
+                              - NONE
+                              - LZ4
+                              - ZLIB
+                              - ZSTD
+                              - SNAPPY
+                              type: string
                             cryptoConfig:
                               properties:
                                 consumerCryptoFailureAction:
@@ -430,6 +466,13 @@ spec:
                         topic:
                           type: string
                         typeClassName:
+                          type: string
+                      type: object
+                    persistentVolumeClaimRetentionPolicy:
+                      properties:
+                        whenDeleted:
+                          type: string
+                        whenScaled:
                           type: string
                       type: object
                     pod:
@@ -3265,11 +3308,22 @@ spec:
                       - atleast_once
                       - atmost_once
                       - effectively_once
+                      - manual
                       type: string
                     pulsar:
                       properties:
                         authConfig:
                           properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
                             oauth2Config:
                               properties:
                                 audience:
@@ -3291,6 +3345,37 @@ spec:
                           type: object
                         authSecret:
                           type: string
+                        cleanupAuthConfig:
+                          properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
+                            oauth2Config:
+                              properties:
+                                audience:
+                                  type: string
+                                issuerUrl:
+                                  type: string
+                                keySecretKey:
+                                  type: string
+                                keySecretName:
+                                  type: string
+                                scope:
+                                  type: string
+                              required:
+                              - audience
+                              - issuerUrl
+                              - keySecretKey
+                              - keySecretName
+                              type: object
+                          type: object
                         pulsarConfig:
                           type: string
                         tlsConfig:
@@ -3313,6 +3398,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -3390,6 +3486,10 @@ spec:
                             type: string
                         type: object
                       type: object
+                    showPreciseParallelism:
+                      type: boolean
+                    skipToLatest:
+                      type: boolean
                     statefulConfig:
                       properties:
                         pulsar:
@@ -3638,6 +3738,8 @@ spec:
                       type: boolean
                     className:
                       type: string
+                    cleanupImage:
+                      type: string
                     cleanupSubscription:
                       type: boolean
                     clusterName:
@@ -3654,6 +3756,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -3691,6 +3804,10 @@ spec:
                       type: object
                     image:
                       type: string
+                    imageHasGet:
+                      type: boolean
+                    imageHasPulsarctl:
+                      type: boolean
                     imagePullPolicy:
                       type: string
                     input:
@@ -3779,6 +3896,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6665,11 +6793,22 @@ spec:
                       - atleast_once
                       - atmost_once
                       - effectively_once
+                      - manual
                       type: string
                     pulsar:
                       properties:
                         authConfig:
                           properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
                             oauth2Config:
                               properties:
                                 audience:
@@ -6691,6 +6830,37 @@ spec:
                           type: object
                         authSecret:
                           type: string
+                        cleanupAuthConfig:
+                          properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
+                            oauth2Config:
+                              properties:
+                                audience:
+                                  type: string
+                                issuerUrl:
+                                  type: string
+                                keySecretKey:
+                                  type: string
+                                keySecretName:
+                                  type: string
+                                scope:
+                                  type: string
+                              required:
+                              - audience
+                              - issuerUrl
+                              - keySecretKey
+                              - keySecretName
+                              type: object
+                          type: object
                         pulsarConfig:
                           type: string
                         tlsConfig:
@@ -6713,6 +6883,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6790,6 +6971,8 @@ spec:
                             type: string
                         type: object
                       type: object
+                    showPreciseParallelism:
+                      type: boolean
                     sinkConfig:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -6863,6 +7046,8 @@ spec:
                       type: object
                     className:
                       type: string
+                    cleanupImage:
+                      type: string
                     clusterName:
                       type: string
                     downloaderImage:
@@ -6877,6 +7062,17 @@ spec:
                           type: string
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6914,6 +7110,10 @@ spec:
                       type: object
                     image:
                       type: string
+                    imageHasGet:
+                      type: boolean
+                    imageHasPulsarctl:
+                      type: boolean
                     imagePullPolicy:
                       type: string
                     java:
@@ -6930,6 +7130,17 @@ spec:
                           type: array
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -6986,6 +7197,14 @@ spec:
                         producerConf:
                           properties:
                             batchBuilder:
+                              type: string
+                            compressionType:
+                              enum:
+                              - NONE
+                              - LZ4
+                              - ZLIB
+                              - ZSTD
+                              - SNAPPY
                               type: string
                             cryptoConfig:
                               properties:
@@ -9869,11 +10088,22 @@ spec:
                       - atleast_once
                       - atmost_once
                       - effectively_once
+                      - manual
                       type: string
                     pulsar:
                       properties:
                         authConfig:
                           properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
                             oauth2Config:
                               properties:
                                 audience:
@@ -9895,6 +10125,37 @@ spec:
                           type: object
                         authSecret:
                           type: string
+                        cleanupAuthConfig:
+                          properties:
+                            genericAuth:
+                              properties:
+                                clientAuthenticationParameters:
+                                  type: string
+                                clientAuthenticationPlugin:
+                                  type: string
+                              required:
+                              - clientAuthenticationParameters
+                              - clientAuthenticationPlugin
+                              type: object
+                            oauth2Config:
+                              properties:
+                                audience:
+                                  type: string
+                                issuerUrl:
+                                  type: string
+                                keySecretKey:
+                                  type: string
+                                keySecretName:
+                                  type: string
+                                scope:
+                                  type: string
+                              required:
+                              - audience
+                              - issuerUrl
+                              - keySecretKey
+                              - keySecretName
+                              type: object
+                          type: object
                         pulsarConfig:
                           type: string
                         tlsConfig:
@@ -9917,6 +10178,17 @@ spec:
                       properties:
                         log:
                           properties:
+                            format:
+                              enum:
+                              - json
+                              - text
+                              type: string
+                            javaLog4JConfigFileType:
+                              enum:
+                              - yaml
+                              - xml
+                              - ini
+                              type: string
                             level:
                               enum:
                               - "off"
@@ -9990,6 +10262,8 @@ spec:
                             type: string
                         type: object
                       type: object
+                    showPreciseParallelism:
+                      type: boolean
                     sourceConfig:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10137,6 +10411,8 @@ spec:
                 type: boolean
               className:
                 type: string
+              cleanupImage:
+                type: string
               cleanupSubscription:
                 type: boolean
               clusterName:
@@ -10158,6 +10434,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -10195,6 +10482,10 @@ spec:
                 type: object
               image:
                 type: string
+              imageHasGet:
+                type: boolean
+              imageHasPulsarctl:
+                type: boolean
               imagePullPolicy:
                 type: string
               input:
@@ -10283,6 +10574,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -10348,6 +10650,14 @@ spec:
                     properties:
                       batchBuilder:
                         type: string
+                      compressionType:
+                        enum:
+                        - NONE
+                        - LZ4
+                        - ZLIB
+                        - ZSTD
+                        - SNAPPY
+                        type: string
                       cryptoConfig:
                         properties:
                           consumerCryptoFailureAction:
@@ -10395,6 +10705,13 @@ spec:
                   topic:
                     type: string
                   typeClassName:
+                    type: string
+                type: object
+              persistentVolumeClaimRetentionPolicy:
+                properties:
+                  whenDeleted:
+                    type: string
+                  whenScaled:
                     type: string
                 type: object
               pod:
@@ -13230,11 +13547,22 @@ spec:
                 - atleast_once
                 - atmost_once
                 - effectively_once
+                - manual
                 type: string
               pulsar:
                 properties:
                   authConfig:
                     properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
                       oauth2Config:
                         properties:
                           audience:
@@ -13256,6 +13584,37 @@ spec:
                     type: object
                   authSecret:
                     type: string
+                  cleanupAuthConfig:
+                    properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
+                      oauth2Config:
+                        properties:
+                          audience:
+                            type: string
+                          issuerUrl:
+                            type: string
+                          keySecretKey:
+                            type: string
+                          keySecretName:
+                            type: string
+                          scope:
+                            type: string
+                        required:
+                        - audience
+                        - issuerUrl
+                        - keySecretKey
+                        - keySecretName
+                        type: object
+                    type: object
                   pulsarConfig:
                     type: string
                   tlsConfig:
@@ -13278,6 +13637,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -13355,6 +13725,10 @@ spec:
                       type: string
                   type: object
                 type: object
+              showPreciseParallelism:
+                type: boolean
+              skipToLatest:
+                type: boolean
               statefulConfig:
                 properties:
                   pulsar:
@@ -13676,6 +14050,8 @@ spec:
                 type: boolean
               className:
                 type: string
+              cleanupImage:
+                type: string
               cleanupSubscription:
                 type: boolean
               clusterName:
@@ -13692,6 +14068,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -13729,6 +14116,10 @@ spec:
                 type: object
               image:
                 type: string
+              imageHasGet:
+                type: boolean
+              imageHasPulsarctl:
+                type: boolean
               imagePullPolicy:
                 type: string
               input:
@@ -13817,6 +14208,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -16703,11 +17105,22 @@ spec:
                 - atleast_once
                 - atmost_once
                 - effectively_once
+                - manual
                 type: string
               pulsar:
                 properties:
                   authConfig:
                     properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
                       oauth2Config:
                         properties:
                           audience:
@@ -16729,6 +17142,37 @@ spec:
                     type: object
                   authSecret:
                     type: string
+                  cleanupAuthConfig:
+                    properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
+                      oauth2Config:
+                        properties:
+                          audience:
+                            type: string
+                          issuerUrl:
+                            type: string
+                          keySecretKey:
+                            type: string
+                          keySecretName:
+                            type: string
+                          scope:
+                            type: string
+                        required:
+                        - audience
+                        - issuerUrl
+                        - keySecretKey
+                        - keySecretName
+                        type: object
+                    type: object
                   pulsarConfig:
                     type: string
                   tlsConfig:
@@ -16751,6 +17195,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -16828,6 +17283,8 @@ spec:
                       type: string
                   type: object
                 type: object
+              showPreciseParallelism:
+                type: boolean
               sinkConfig:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -16974,6 +17431,8 @@ spec:
                 type: object
               className:
                 type: string
+              cleanupImage:
+                type: string
               clusterName:
                 type: string
               downloaderImage:
@@ -16988,6 +17447,17 @@ spec:
                     type: string
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -17025,6 +17495,10 @@ spec:
                 type: object
               image:
                 type: string
+              imageHasGet:
+                type: boolean
+              imageHasPulsarctl:
+                type: boolean
               imagePullPolicy:
                 type: string
               java:
@@ -17041,6 +17515,17 @@ spec:
                     type: array
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -17097,6 +17582,14 @@ spec:
                   producerConf:
                     properties:
                       batchBuilder:
+                        type: string
+                      compressionType:
+                        enum:
+                        - NONE
+                        - LZ4
+                        - ZLIB
+                        - ZSTD
+                        - SNAPPY
                         type: string
                       cryptoConfig:
                         properties:
@@ -19980,11 +20473,22 @@ spec:
                 - atleast_once
                 - atmost_once
                 - effectively_once
+                - manual
                 type: string
               pulsar:
                 properties:
                   authConfig:
                     properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
                       oauth2Config:
                         properties:
                           audience:
@@ -20006,6 +20510,37 @@ spec:
                     type: object
                   authSecret:
                     type: string
+                  cleanupAuthConfig:
+                    properties:
+                      genericAuth:
+                        properties:
+                          clientAuthenticationParameters:
+                            type: string
+                          clientAuthenticationPlugin:
+                            type: string
+                        required:
+                        - clientAuthenticationParameters
+                        - clientAuthenticationPlugin
+                        type: object
+                      oauth2Config:
+                        properties:
+                          audience:
+                            type: string
+                          issuerUrl:
+                            type: string
+                          keySecretKey:
+                            type: string
+                          keySecretName:
+                            type: string
+                          scope:
+                            type: string
+                        required:
+                        - audience
+                        - issuerUrl
+                        - keySecretKey
+                        - keySecretName
+                        type: object
+                    type: object
                   pulsarConfig:
                     type: string
                   tlsConfig:
@@ -20028,6 +20563,17 @@ spec:
                 properties:
                   log:
                     properties:
+                      format:
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      javaLog4JConfigFileType:
+                        enum:
+                        - yaml
+                        - xml
+                        - ini
+                        type: string
                       level:
                         enum:
                         - "off"
@@ -20101,6 +20647,8 @@ spec:
                       type: string
                   type: object
                 type: object
+              showPreciseParallelism:
+                type: boolean
               sourceConfig:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Fixes https://github.com/streamnative/function-mesh/issues/661

### Motivation

allow user to select `xml` or `yaml` for java log4j config file extension.

### Modifications

- add `Format` to `RuntimeLogConfig`
- add `JavaLog4JConfigFileType` to `RuntimeLogConfig`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

