### PR TITLE
bump k8s to 1.23.17

### DIFF
--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -35,7 +35,7 @@ FUNCTION_NAME=$1
 
 function ci::create_cluster() {
     echo "Creating a kind cluster ..."
-    ${FUNCTION_MESH_HOME}/hack/kind-cluster-build.sh --name sn-platform-"${CLUSTER_ID}" -c 3 -v 10 -k v1.22.15
+    ${FUNCTION_MESH_HOME}/hack/kind-cluster-build.sh --name sn-platform-"${CLUSTER_ID}" -c 3 -v 10 -k v1.23.17
     echo "Successfully created a kind cluster."
 }
 

--- a/.ci/tests/kind.yaml
+++ b/.ci/tests/kind.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatchesJSON6902:
 nodes:
   # the control plane node (worker) config
   - role: control-plane
-    image: kindest/node:v1.22.15
+    image: kindest/node:v1.23.17
     extraPortMappings:
       - containerPort: 31234
         hostPort: 31234

--- a/.github/workflows/olm-verify.yml
+++ b/.github/workflows/olm-verify.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v1
         with:
-          node_image: kindest/node:v1.22.15
+          node_image: kindest/node:v1.23.17
 
       - name: Build RedHat certificated bundle And Publish to Quay
         env:

--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Create kind cluster
-        run: hack/kind-cluster-build.sh --name chart-testing -c 1 -v 10 --k8sVersion v1.22.15
+        run: hack/kind-cluster-build.sh --name chart-testing -c 1 -v 10 --k8sVersion v1.23.17
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Set up GO 1.20.4

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ OPTIONS:
     -c  --crd                The path of the crd files.
         --kind-version       Version of the Kind tool, default value: v0.7.0
         --node-num           The count of the cluster nodes, default value: 2
-        --k8s-version        Version of the Kubernetes cluster, default value: v1.22.15
+        --k8s-version        Version of the Kubernetes cluster, default value: v1.23.17
         --volume-num         The volumes number of each kubernetes node, default value: 2
         --release-name       Release name of function-mesh, default value: function-mesh
         --namespace          Namespace of function-mesh, default value: default
@@ -60,7 +60,7 @@ main() {
   local kind_name="kind"
   local kind_version="v0.7.0"
   local node_num=2
-  local k8s_version="v1.22.15"
+  local k8s_version="v1.23.17"
   local volume_num=2
   local release_name="function-mesh"
   local namespace="default"


### PR DESCRIPTION
### Motivation

validate the CI with k8s 1.23.17 and try to solve CI issue from https://github.com/streamnative/function-mesh/pull/658

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

