### PR TITLE
Decide to whether use pulsarctl based on image name

### DIFF
--- a/.ci/tests/integration-oauth2/cases/java-download-function/manifests.yaml
+++ b/.ci/tests/integration-oauth2/cases/java-download-function/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-java-runner:2.9.2.23
-  imageHasPulsarctl: true
   className: org.apache.pulsar.functions.api.examples.ExclamationFunction
   cleanupSubscription: true
   subscriptionName: java-download-subscription

--- a/.ci/tests/integration-oauth2/cases/py-download-from-http-function/manifests.yaml
+++ b/.ci/tests/integration-oauth2/cases/py-download-from-http-function/manifests.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-python-runner:2.9.2.23
-  imageHasPulsarctl: true
-  imageHasWget: true
   className: exclamation
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000

--- a/.ci/tests/integration-oauth2/cases/py-download-function-legacy/manifests.yaml
+++ b/.ci/tests/integration-oauth2/cases/py-download-function-legacy/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-python-runner:2.9.2.23
-  imageHasPulsarctl: true
   className: exclamation_function.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000

--- a/.ci/tests/integration-oauth2/cases/py-download-function/manifests.yaml
+++ b/.ci/tests/integration-oauth2/cases/py-download-function/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-python-runner:2.9.2.23
-  imageHasPulsarctl: true
   className: exclamation_function.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000

--- a/.ci/tests/integration/cases/go-download-function/manifests.yaml
+++ b/.ci/tests/integration/cases/go-download-function/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-go-runner:2.9.2.23
-  imageHasPulsarctl: true
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000
   replicas: 1

--- a/.ci/tests/integration/cases/java-download-function/manifests.yaml
+++ b/.ci/tests/integration/cases/java-download-function/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-java-runner:2.9.2.23
-  imageHasPulsarctl: true
   className: org.apache.pulsar.functions.api.examples.ExclamationFunction
   cleanupSubscription: true
   subscriptionName: java-download-subscription

--- a/.ci/tests/integration/cases/py-download-pip-function/manifests.yaml
+++ b/.ci/tests/integration/cases/py-download-pip-function/manifests.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   image: streamnative/pulsar-functions-pulsarctl-python-runner:2.9.2.23
-  imageHasPulsarctl: true
   className: pulsarfunction.exclamation.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -65,6 +65,10 @@ const (
 	PulsarAdminExecutableFile  = "/pulsar/bin/pulsar-admin"
 	WorkDir                    = "/pulsar/"
 
+	JavaRunnerImageHasPulsarctl   = "pulsar-functions-pulsarctl-java-runner"
+	PythonRunnerImageHasPulsarctl = "pulsar-functions-pulsarctl-python-runner"
+	GolangRunnerImageHasPulsarctl = "pulsar-functions-pulsarctl-go-runner"
+
 	PulsarctlExecutableFile = "/usr/local/bin/pulsarctl"
 	DownloaderName          = "downloader"
 	DownloaderVolume        = "downloader-volume"
@@ -362,8 +366,14 @@ func MakeGoFunctionCommand(downloadPath, goExecFilePath string, function *v1alph
 		strings.Join(getProcessGoRuntimeArgs(goExecFilePath, function), " ")
 	if downloadPath != "" && !utils.EnableInitContainers {
 		// prepend download command if the downPath is provided
+		hasPulsarctl := function.Spec.ImageHasPulsarctl
+		hasWget := function.Spec.ImageHasWget
+		if strings.Contains(function.Spec.Image, GolangRunnerImageHasPulsarctl) {
+			hasPulsarctl = true
+			hasWget = true
+		}
 		downloadCommand := strings.Join(getDownloadCommand(downloadPath, goExecFilePath,
-			function.Spec.ImageHasPulsarctl, function.Spec.ImageHasWget, function.Spec.Pulsar.AuthSecret != "",
+			hasPulsarctl, hasWget, function.Spec.Pulsar.AuthSecret != "",
 			function.Spec.Pulsar.TLSSecret != "", function.Spec.Pulsar.TLSConfig, function.Spec.Pulsar.AuthConfig), " ")
 		processCommand = downloadCommand + " && ls -al && pwd &&" + processCommand
 	}


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #629

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Use pulsarctl when runner image name contains `pulsar-functions-pulsarctl-(java|go|python)-runner`, so users don't need to pass the `imageHasPulsarctl` manually

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

