### PR TITLE
Use regex to check whether runner image has pulsarctl

### DIFF
--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -378,8 +378,7 @@ func MakeGoFunctionCommand(downloadPath, goExecFilePath string, function *v1alph
 		// prepend download command if the downPath is provided
 		hasPulsarctl := function.Spec.ImageHasPulsarctl
 		hasWget := function.Spec.ImageHasWget
-		match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
-		if match == true {
+		if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image); match {
 			hasPulsarctl = true
 			hasWget = true
 		}

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -20,6 +20,7 @@ package spec
 import (
 	"bytes"
 	"context"
+	"regexp"
 
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 
@@ -65,11 +66,9 @@ const (
 	PulsarAdminExecutableFile  = "/pulsar/bin/pulsar-admin"
 	WorkDir                    = "/pulsar/"
 
-	JavaRunnerImageHasPulsarctl   = "pulsar-functions-pulsarctl-java-runner"
-	PythonRunnerImageHasPulsarctl = "pulsar-functions-pulsarctl-python-runner"
-	GolangRunnerImageHasPulsarctl = "pulsar-functions-pulsarctl-go-runner"
+	RunnerImageHasPulsarctl = "pulsar-functions-(pulsarctl|sn)-(java|python|go)-runner"
 
-	PulsarctlExecutableFile = "/usr/local/bin/pulsarctl"
+	PulsarctlExecutableFile = "pulsarctl"
 	DownloaderName          = "downloader"
 	DownloaderVolume        = "downloader-volume"
 	DownloaderImage         = DefaultRunnerPrefix + "pulsarctl:2.10.2.3"
@@ -379,7 +378,8 @@ func MakeGoFunctionCommand(downloadPath, goExecFilePath string, function *v1alph
 		// prepend download command if the downPath is provided
 		hasPulsarctl := function.Spec.ImageHasPulsarctl
 		hasWget := function.Spec.ImageHasWget
-		if strings.Contains(function.Spec.Image, GolangRunnerImageHasPulsarctl) {
+		match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
+		if match == true {
 			hasPulsarctl = true
 			hasWget = true
 		}
@@ -533,6 +533,7 @@ func getPulsarAdminCommand(authProvided, tlsProvided bool, tlsConfig TLSConfig,
 func getPulsarctlCommand(authProvided, tlsProvided bool, tlsConfig TLSConfig,
 	authConfig *v1alpha1.AuthConfig) []string {
 	args := []string{
+		"export PATH=$PATH:/pulsar/bin && ",
 		PulsarctlExecutableFile,
 		"--admin-service-url",
 		"$webServiceURL",
@@ -541,6 +542,7 @@ func getPulsarctlCommand(authProvided, tlsProvided bool, tlsConfig TLSConfig,
 	if authConfig != nil {
 		if authConfig.OAuth2Config != nil {
 			args = []string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"context",
 				"set",
@@ -568,6 +570,7 @@ func getPulsarctlCommand(authProvided, tlsProvided bool, tlsConfig TLSConfig,
 			}...)
 		} else if authConfig.GenericAuth != nil {
 			args = []string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				"( " + PulsarctlExecutableFile,
 				"oauth2",
 				"activate",
@@ -585,6 +588,7 @@ func getPulsarctlCommand(authProvided, tlsProvided bool, tlsConfig TLSConfig,
 		}
 	} else if authProvided {
 		args = []string{
+			"export PATH=$PATH:/pulsar/bin && ",
 			"( " + PulsarctlExecutableFile,
 			"oauth2",
 			"activate",

--- a/controllers/spec/common_test.go
+++ b/controllers/spec/common_test.go
@@ -49,6 +49,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		// test get the download command with package name
 		{"function://public/default/test@v1", "function-package.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"packages", "download", "function://public/default/test@v1", "--path", "function-package.jar",
@@ -57,6 +58,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		},
 		{"sink://public/default/test@v1", "sink-package.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"packages", "download", "sink://public/default/test@v1", "--path", "sink-package.jar",
@@ -65,6 +67,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		},
 		{"source://public/default/test@v1", "source-package.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"packages", "download", "source://public/default/test@v1", "--path", "source-package.jar",
@@ -74,6 +77,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		// test get the download command with normal name
 		{"/test", "test.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"functions", "download", "--path", "/test", "--destination-file", "test.jar",
@@ -83,6 +87,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		// test get the download command with a wrong package name
 		{"source/public/default/test@v1", "source-package.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"functions", "download", "--path", "source/public/default/test@v1", "--destination-file", "source-package.jar",
@@ -91,6 +96,7 @@ func TestGetDownloadCommand(t *testing.T) {
 		},
 		{"source:/public/default/test@v1", "source-package.jar", nil, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"functions", "download", "--path", "source:/public/default/test@v1", "--destination-file", "source-package.jar",
@@ -106,6 +112,7 @@ func TestGetDownloadCommand(t *testing.T) {
 				KeySecretKey:  "auth.json",
 			}, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"context",
 				"set",
@@ -138,6 +145,7 @@ func TestGetDownloadCommand(t *testing.T) {
 				},
 			}, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"--tls-allow-insecure=false",
@@ -158,6 +166,7 @@ func TestGetDownloadCommand(t *testing.T) {
 				},
 			}, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"packages", "download", "function://public/default/test@v1", "--path", "function-package.jar",
@@ -175,6 +184,7 @@ func TestGetDownloadCommand(t *testing.T) {
 				},
 			}, nil, nil,
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				PulsarctlExecutableFile,
 				"--admin-service-url", "$webServiceURL",
 				"--tls-allow-insecure=true",
@@ -198,6 +208,7 @@ func TestGetDownloadCommand(t *testing.T) {
 				ClientAuthenticationPlugin:     "auth-plugin",
 			},
 			[]string{
+				"export PATH=$PATH:/pulsar/bin && ",
 				"( " + PulsarctlExecutableFile,
 				"oauth2",
 				"activate",

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -18,7 +18,7 @@
 package spec
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/streamnative/function-mesh/utils"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -112,9 +112,8 @@ func MakeFunctionCleanUpJob(function *v1alpha1.Function) *v1.Job {
 		}
 	}
 	hasPulsarctl := function.Spec.ImageHasPulsarctl
-	if strings.Contains(function.Spec.Image, JavaRunnerImageHasPulsarctl) ||
-		strings.Contains(function.Spec.Image, PythonRunnerImageHasPulsarctl) ||
-		strings.Contains(function.Spec.Image, GolangRunnerImageHasPulsarctl) {
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
+	if match == true {
 		hasPulsarctl = true
 	}
 	command := getCleanUpCommand(hasPulsarctl,
@@ -210,12 +209,13 @@ func makeFunctionCommand(function *v1alpha1.Function) []string {
 
 	hasPulsarctl := function.Spec.ImageHasPulsarctl
 	hasWget := function.Spec.ImageHasWget
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
+	if match == true {
+		hasPulsarctl = true
+		hasWget = true
+	}
 	if spec.Java != nil {
 		if spec.Java.Jar != "" {
-			if strings.Contains(function.Spec.Image, JavaRunnerImageHasPulsarctl) {
-				hasPulsarctl = true
-				hasWget = true
-			}
 			return MakeJavaFunctionCommand(spec.Java.JarLocation, spec.Java.Jar,
 				spec.Name, spec.ClusterName,
 				generateJavaLogConfigCommand(function.Spec.Java, function.Spec.LogTopicAgent),
@@ -231,13 +231,9 @@ func makeFunctionCommand(function *v1alpha1.Function) []string {
 		}
 	} else if spec.Python != nil {
 		if spec.Python.Py != "" {
-			if strings.Contains(function.Spec.Image, PythonRunnerImageHasPulsarctl) {
-				hasPulsarctl = true
-				hasWget = true
-			}
 			return MakePythonFunctionCommand(spec.Python.PyLocation, spec.Python.Py,
 				spec.Name, spec.ClusterName,
-        generatePythonLogConfigCommand(function.Name, function.Spec.Python, function.Spec.LogTopicAgent),
+				generatePythonLogConfigCommand(function.Name, function.Spec.Python, function.Spec.LogTopicAgent),
 				generateFunctionDetailsInJSON(function), string(function.UID), hasPulsarctl, hasWget,
 				spec.Pulsar.AuthSecret != "", spec.Pulsar.TLSSecret != "", function.Spec.SecretsMap,
 				function.Spec.StateConfig, function.Spec.Pulsar.TLSConfig, function.Spec.Pulsar.AuthConfig)

--- a/controllers/spec/function.go
+++ b/controllers/spec/function.go
@@ -112,8 +112,7 @@ func MakeFunctionCleanUpJob(function *v1alpha1.Function) *v1.Job {
 		}
 	}
 	hasPulsarctl := function.Spec.ImageHasPulsarctl
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image); match {
 		hasPulsarctl = true
 	}
 	command := getCleanUpCommand(hasPulsarctl,
@@ -209,8 +208,7 @@ func makeFunctionCommand(function *v1alpha1.Function) []string {
 
 	hasPulsarctl := function.Spec.ImageHasPulsarctl
 	hasWget := function.Spec.ImageHasWget
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, function.Spec.Image); match {
 		hasPulsarctl = true
 		hasWget = true
 	}

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -18,7 +18,7 @@
 package spec
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/streamnative/function-mesh/utils"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -159,7 +159,8 @@ func MakeSinkCleanUpJob(sink *v1alpha1.Sink) *v1.Job {
 		}
 	}
 	imageHasPulsarctl := sink.Spec.ImageHasPulsarctl
-	if strings.Contains(sink.Spec.Image, JavaRunnerImageHasPulsarctl) {
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image)
+	if match == true {
 		imageHasPulsarctl = true
 	}
 	command := getCleanUpCommand(imageHasPulsarctl,
@@ -203,7 +204,8 @@ func MakeSinkCommand(sink *v1alpha1.Sink) []string {
 	spec := sink.Spec
 	hasPulsarctl := sink.Spec.ImageHasPulsarctl
 	hasWget := sink.Spec.ImageHasWget
-	if strings.Contains(spec.Image, JavaRunnerImageHasPulsarctl) {
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image)
+	if match == true {
 		hasPulsarctl = true
 		hasWget = true
 	}

--- a/controllers/spec/sink.go
+++ b/controllers/spec/sink.go
@@ -159,8 +159,7 @@ func MakeSinkCleanUpJob(sink *v1alpha1.Sink) *v1.Job {
 		}
 	}
 	imageHasPulsarctl := sink.Spec.ImageHasPulsarctl
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image); match {
 		imageHasPulsarctl = true
 	}
 	command := getCleanUpCommand(imageHasPulsarctl,
@@ -204,8 +203,7 @@ func MakeSinkCommand(sink *v1alpha1.Sink) []string {
 	spec := sink.Spec
 	hasPulsarctl := sink.Spec.ImageHasPulsarctl
 	hasWget := sink.Spec.ImageHasWget
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, sink.Spec.Image); match {
 		hasPulsarctl = true
 		hasWget = true
 	}

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -150,8 +150,7 @@ func makeSourceCommand(source *v1alpha1.Source) []string {
 	spec := source.Spec
 	hasPulsarctl := source.Spec.ImageHasPulsarctl
 	hasWget := source.Spec.ImageHasWget
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image); match {
 		hasPulsarctl = true
 		hasWget = true
 	}
@@ -202,8 +201,7 @@ func MakeSourceCleanUpJob(source *v1alpha1.Source) *v1.Job {
 	}
 
 	hasPulsarctl := source.Spec.ImageHasPulsarctl
-	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image)
-	if match == true {
+	if match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image); match {
 		hasPulsarctl = true
 	}
 	command := getCleanUpCommand(hasPulsarctl,

--- a/controllers/spec/source.go
+++ b/controllers/spec/source.go
@@ -19,7 +19,7 @@ package spec
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/streamnative/function-mesh/utils"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -150,7 +150,8 @@ func makeSourceCommand(source *v1alpha1.Source) []string {
 	spec := source.Spec
 	hasPulsarctl := source.Spec.ImageHasPulsarctl
 	hasWget := source.Spec.ImageHasWget
-	if strings.Contains(spec.Image, JavaRunnerImageHasPulsarctl) {
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image)
+	if match == true {
 		hasPulsarctl = true
 		hasWget = true
 	}
@@ -201,7 +202,8 @@ func MakeSourceCleanUpJob(source *v1alpha1.Source) *v1.Job {
 	}
 
 	hasPulsarctl := source.Spec.ImageHasPulsarctl
-	if strings.Contains(source.Spec.Image, JavaRunnerImageHasPulsarctl) {
+	match, _ := regexp.MatchString(RunnerImageHasPulsarctl, source.Spec.Image)
+	if match == true {
 		hasPulsarctl = true
 	}
 	command := getCleanUpCommand(hasPulsarctl,


### PR DESCRIPTION
### Motivation

Some runner images(such as pulsar-functions-sn-java-runner) may has `pulsarctl` in `/pulsar/bin` dir, but we are using `/usr/local/bin/pulsarctl` as the pulsarctl path, so it's better to use `pulsarctl` directly and add `/pulsar/bin` to the `$PATH`

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

