### PR TITLE
Do not create filebeat container when log topic is not set

### DIFF
--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -2110,7 +2110,7 @@ func getSubscriptionNameOrDefault(subscription, tenant, namespace, name string) 
 func makeFilebeatContainer(volumeMounts []corev1.VolumeMount, envVar []corev1.EnvVar, name string, logTopic string,
 	agent v1alpha1.LogTopicAgent, tlsConfig TLSConfig, authConfig *v1alpha1.AuthConfig,
 	pulsarConfig string, authSecret string, tlsSecret string, image string) *corev1.Container {
-	if agent != v1alpha1.SIDECAR {
+	if logTopic == "" || agent != v1alpha1.SIDECAR {
 		return nil
 	}
 	filebeatImage := image

--- a/pkg/webhook/function_webhook.go
+++ b/pkg/webhook/function_webhook.go
@@ -153,7 +153,7 @@ func (webhook *FunctionWebhook) Default(ctx context.Context, obj runtime.Object)
 		}
 	}
 
-	if r.Spec.LogTopicAgent == "" {
+	if r.Spec.LogTopic != "" && r.Spec.LogTopicAgent == "" {
 		r.Spec.LogTopicAgent = v1alpha1.RUNTIME
 	}
 

--- a/pkg/webhook/sink_webhook.go
+++ b/pkg/webhook/sink_webhook.go
@@ -125,7 +125,7 @@ func (webhook *SinkWebhook) Default(ctx context.Context, obj runtime.Object) err
 		r.Spec.Input.TypeClassName = "[B"
 	}
 
-	if r.Spec.LogTopicAgent == "" {
+	if r.Spec.LogTopic != "" && r.Spec.LogTopicAgent == "" {
 		r.Spec.LogTopicAgent = v1alpha1.SIDECAR
 	}
 

--- a/pkg/webhook/source_webhook.go
+++ b/pkg/webhook/source_webhook.go
@@ -135,7 +135,7 @@ func (webhook *SourceWebhook) Default(ctx context.Context, obj runtime.Object) e
 		r.Spec.Output.TypeClassName = "[B"
 	}
 
-	if r.Spec.LogTopicAgent == "" {
+	if r.Spec.LogTopic != "" && r.Spec.LogTopicAgent == "" {
 		r.Spec.LogTopicAgent = v1alpha1.SIDECAR
 	}
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Even no log topic is specified, it will start a filebeat container, we should avoid that

### Modifications

Only create filebeat container when log topic is set and the `logTopicAgent == sidecar` 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

