### PR TITLE
fix permission for cleanupSubscription on OLM installation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -166,6 +166,30 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -336,3 +336,11 @@ func ConvertHPAV2ToV2beta2(hpa *autov2.HorizontalPodAutoscaler) *autoscalingv2be
 
 	return result
 }
+
+func getBackgroundDeletionPolicy() client.DeleteOption {
+	backgroundDeletion := metav1.DeletePropagationBackground
+	var deleteOptions client.DeleteOption = &client.DeleteOptions{
+		PropagationPolicy: &backgroundDeletion,
+	}
+	return deleteOptions
+}

--- a/controllers/function_controller.go
+++ b/controllers/function_controller.go
@@ -59,6 +59,8 @@ type FunctionReconciler struct {
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;delete

--- a/controllers/sink.go
+++ b/controllers/sink.go
@@ -332,7 +332,7 @@ func (r *SinkReconciler) ApplySinkVPA(ctx context.Context, sink *v1alpha1.Sink) 
 func (r *SinkReconciler) ApplySinkCleanUpJob(ctx context.Context, sink *v1alpha1.Sink) error {
 	if !spec.NeedCleanup(sink) {
 		desiredJob := spec.MakeSinkCleanUpJob(sink)
-		if err := r.Delete(ctx, desiredJob); err != nil {
+		if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 			if errors.IsNotFound(err) {
 				return nil
 			}
@@ -376,7 +376,7 @@ func (r *SinkReconciler) ApplySinkCleanUpJob(ctx context.Context, sink *v1alpha1
 				}
 			} else {
 				// delete the cleanup job
-				if err := r.Delete(ctx, desiredJob); err != nil {
+				if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 					return err
 				}
 			}
@@ -391,7 +391,7 @@ func (r *SinkReconciler) ApplySinkCleanUpJob(ctx context.Context, sink *v1alpha1
 
 			desiredJob := spec.MakeSinkCleanUpJob(sink)
 			// delete the cleanup job
-			if err := r.Delete(ctx, desiredJob); err != nil {
+			if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 				return err
 			}
 

--- a/controllers/sink_controller.go
+++ b/controllers/sink_controller.go
@@ -58,6 +58,9 @@ type SinkReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;delete

--- a/controllers/source.go
+++ b/controllers/source.go
@@ -334,7 +334,7 @@ func (r *SourceReconciler) ApplySourceVPA(ctx context.Context, source *v1alpha1.
 func (r *SourceReconciler) ApplySourceCleanUpJob(ctx context.Context, source *v1alpha1.Source) error {
 	if !spec.NeedCleanup(source) {
 		desiredJob := spec.MakeSourceCleanUpJob(source)
-		if err := r.Delete(ctx, desiredJob); err != nil {
+		if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 			if errors.IsNotFound(err) {
 				return nil
 			}
@@ -378,7 +378,7 @@ func (r *SourceReconciler) ApplySourceCleanUpJob(ctx context.Context, source *v1
 				}
 			} else {
 				// delete the cleanup job
-				if err := r.Delete(ctx, desiredJob); err != nil {
+				if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 					return err
 				}
 			}
@@ -393,7 +393,7 @@ func (r *SourceReconciler) ApplySourceCleanUpJob(ctx context.Context, source *v1
 
 			desiredJob := spec.MakeSourceCleanUpJob(source)
 			// delete the cleanup job
-			if err := r.Delete(ctx, desiredJob); err != nil {
+			if err := r.Delete(ctx, desiredJob, getBackgroundDeletionPolicy()); err != nil {
 				return err
 			}
 

--- a/controllers/source_controller.go
+++ b/controllers/source_controller.go
@@ -57,6 +57,9 @@ type SourceReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;delete


### PR DESCRIPTION
### Motivation

```
W1024 08:06:04.290819       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:sn-system:function-mesh-controller-manager" cannot list resource "pods" in API group "" at the cluster scope
```

Failed to cleanupSubscription on OLM installation.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

