### PR TITLE
fix olm bundle labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ redhat-certificated-bundle: yq kustomize manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(shell docker inspect --format='{{json .RepoDigests}}' $(OPERATOR_IMG) | jq --arg IMAGE_TAG_BASE "$(IMAGE_TAG_BASE)" -c '.[] | select(index($$IMAGE_TAG_BASE))' -r)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(YQ) eval -i ".metadata.annotations.\"olm.skipRange\" = \"<$(VERSION)\"" bundle/manifests/function-mesh.clusterserviceversion.yaml
-	$(YQ) eval -i ".metadata.annotations.\"olm.properties\" = ([{\"type\": \"olm.maxOpenShiftVersion\", \"value\": \"4.11\"}] | @json)" bundle/manifests/function-mesh.clusterserviceversion.yaml
+	$(YQ) eval -i ".metadata.annotations.\"olm.properties\" = ([{\"type\": \"olm.maxOpenShiftVersion\", \"value\": \"4.13\"}] | @json)" bundle/manifests/function-mesh.clusterserviceversion.yaml
 	$(YQ) eval -i ".metadata.annotations.createdAt = \"$(BUILD_DATETIME)\"" bundle/manifests/function-mesh.clusterserviceversion.yaml
 	$(YQ) eval -i ".metadata.annotations.containerImage = \"$(shell docker inspect --format='{{json .RepoDigests}}' $(OPERATOR_IMG) | jq --arg IMAGE_TAG_BASE "$(IMAGE_TAG_BASE)" -c '.[] | select(index($$IMAGE_TAG_BASE))' -r)\"" bundle/manifests/function-mesh.clusterserviceversion.yaml
 	$(YQ) eval -i '.annotations += {"operators.operatorframework.io.bundle.channel.default.v1":"alpha"}' bundle/metadata/annotations.yaml

--- a/config/manifests/bases/function-mesh.clusterserviceversion.yaml
+++ b/config/manifests/bases/function-mesh.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     containerImage: streamnative/function-mesh-operator:v0.0.0
     description: The Function Mesh Operator manages the Pulsar Functions and Connectors
       deployed on a Kubernetes cluster.
-    operatorhub.io/ui-metadata-max-k8s-version: "1.24"
+    operatorhub.io/ui-metadata-max-k8s-version: "1.26"
     repository: https://github.com/streamnative/function-mesh
     support: StreamNative
   name: function-mesh.v0.0.0
@@ -72,7 +72,7 @@ spec:
   - email: function-mesh@streamnative.io
     name: Function Mesh
   maturity: alpha
-  minKubeVersion: v1.17.0
+  minKubeVersion: v1.23.0
   provider:
     name: StreamNative
     url: https://streamnative.io

--- a/hack/postprocess-bundle.sh
+++ b/hack/postprocess-bundle.sh
@@ -21,14 +21,14 @@
 # These labels are required to be in the bundle.Dockerfile, but can't be added by the operator-sdk automatically
 cat <<EOF >> bundle.Dockerfile
 # Certified Openshift required labels
-LABEL com.redhat.openshift.versions="v4.8-v4.11"
+LABEL com.redhat.openshift.versions="v4.10-v4.13"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true
 LABEL operators.operatorframework.io.bundle.channel.default.v1="alpha"
 EOF
 
 # Add them to the bundle metadata also
-yq eval -i '.annotations."com.redhat.openshift.versions" = "v4.8-v4.11"' bundle/metadata/annotations.yaml
+yq eval -i '.annotations."com.redhat.openshift.versions" = "v4.10-v4.13"' bundle/metadata/annotations.yaml
 yq eval -i '.annotations."com.redhat.delivery.operator.bundle" = true' bundle/metadata/annotations.yaml
 yq eval -i '.annotations."com.redhat.delivery.backport" = true' bundle/metadata/annotations.yaml
 yq eval -i '.annotations."operators.operatorframework.io.bundle.channel.default.v1" = "alpha"' bundle/metadata/annotations.yaml


### PR DESCRIPTION

### Motivation

```
time="2023-10-23T13:18:08Z" level=info msg="check completed" check=DeployableByOLM err="the bundle cannot be deployed because deployment validation has failed: [{Name:function-mesh.v0.18.0 Errors:[Error: Value : (function-mesh.v0.18.0) csv.Spec.MinKubeVersion has an invalid value: v1.17.0] Warnings:[Warning: Value function-mesh.v0.18.0: this bundle is using APIs which were deprecated and removed in v1.25. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. Migrate the API(s) for horizontalpodautoscalers: ([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[0].Rules[1]\"])]} {Name:function-mesh.v0.18.0 Errors:[Error: Value : (function-mesh.v0.18.0) csv.Spec.MinKubeVersion has an invalid value: v1.17.0] Warnings:[Warning: Value : found olm.properties annotation, please define these properties in metadata/properties.yaml instead]}]" result=ERROR
```

error from openshift certification process

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

