### PR TITLE
Use numeric uid:gid in Dockerfile to support Tanzu's PSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
### Motivation

Tanzu Kubernetes Grid 1.22.9 requires that docker images have numeric userids. Running an distroless nonroot image with "USER nonroot:nonroot" will fail to start with this error when default pod security policy is enabled:
"Error: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root"

### Modifications

Replace `USER nonroot:nonroot` with `USER 65532:65532`. 
Similar solution is commonly used for images using distroless nonroot base image.
For example, https://github.com/grafana/loki/blob/main/operator/Dockerfile#L26

### Other context

Related to https://github.com/streamnative/eng-support-tickets/issues/980 , although sql-operator hasn't been specifically mentioned. It's better to make all images ready for such k8s environments where numeric user ids are required in images.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

