### PR TITLE
Bump go to 1.22.3 to fix CVE-2024-24788

### DIFF
--- a/.github/workflows/bundle-release.yml
+++ b/.github/workflows/bundle-release.yml
@@ -42,10 +42,10 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: InstallKubebuilder
@@ -166,10 +166,10 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: InstallKubebuilder

--- a/.github/workflows/olm-verify.yml
+++ b/.github/workflows/olm-verify.yml
@@ -27,10 +27,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: InstallKubebuilder

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.9, 1.22.2]
+        go-version: [1.21.9, 1.22.3]
     steps:
       - name: clean disk
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: InstallKubebuilder

--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -76,11 +76,11 @@ jobs:
         run: hack/kind-cluster-build.sh --name chart-testing -c 1 -v 10 --k8sVersion v1.23.17
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         if: steps.list-changed.outputs.changed == 'true'
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: setup kubebuilder 3.6.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,10 +23,10 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up GO 1.22.2
+      - name: Set up GO 1.22.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.22.2
+          go-version: 1.22.3
         id: go
 
       - name: InstallKubebuilder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.2-bullseye as builder
+FROM golang:1.22.3-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/redhat.Dockerfile
+++ b/redhat.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.2-bullseye as builder
+FROM golang:1.22.3-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
### Motivation

Resolves build CVE by updating Golang to 1.22.3, resolving CVE-2024-24788

### Modifications

Updating build and golang defniitions.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
 
This is modifying internals to the build.