### PR TITLE
Add permissions to the specific scan job to try fixing trivy

### DIFF
--- a/.github/workflows/trivy_scheduled_master.yml
+++ b/.github/workflows/trivy_scheduled_master.yml
@@ -30,6 +30,9 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      security-events: write
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation

The scheduled Trivy job on the master branch is failing, it looks like a permission issue. This PR adds in job specific permissions. Oddly though the global permissions should have worked, I'm making an assumption that the action has an issue or that the permissions are overrided.

### Modifications

Add permissions to scheduled Trivy specific job.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 

CI change.

