### PR TITLE
added feature to provide imagePullSecrets and imagePullPolicy to runn…

### DIFF
--- a/charts/function-mesh-operator/templates/controller-manager-configmap.yaml
+++ b/charts/function-mesh-operator/templates/controller-manager-configmap.yaml
@@ -15,6 +15,14 @@ data:
     runnerImages:
 {{ toYaml .Values.controllerManager.runnerImages | indent 6 }}
     {{- end }}
+    {{- if .Values.controllerManager.runnerImagePullSecrets }}
+    runnerImagePullSecrets:
+{{ toYaml .Values.controllerManager.runnerImagePullSecrets | indent 6 }}
+    {{- end }}
+    {{- if .Values.controllerManager.runnerImagePullPolicy }}
+    runnerImagePullPolicy:
+{{ toYaml .Values.controllerManager.runnerImagePullPolicy | indent 6 }}
+    {{- end }}
     {{- if .Values.controllerManager.resourceLabels }}
     resourceLabels:
 {{ toYaml .Values.controllerManager.resourceLabels | indent 6 }}

--- a/controllers/spec/common.go
+++ b/controllers/spec/common.go
@@ -1923,6 +1923,14 @@ func generateAnnotations(customAnnotations ...map[string]string) map[string]stri
 	return annotations
 }
 
+func getFunctionRunnerImagePullSecret() []map[string]string {
+	return Configs.RunnerImagePullSecrets
+}
+
+func getFunctionRunnerImagePullPolicy() corev1.PullPolicy {
+	return Configs.RunnerImagePullPolicy
+}
+
 func getFunctionRunnerImage(spec *v1alpha1.FunctionSpec) string {
 	runtime := &spec.Runtime
 	img := spec.Image
@@ -1940,6 +1948,14 @@ func getFunctionRunnerImage(spec *v1alpha1.FunctionSpec) string {
 	return DefaultRunnerImage
 }
 
+func getSinkRunnerImagePullSecret() []map[string]string {
+	return Configs.RunnerImagePullSecrets
+}
+
+func getSinkRunnerImagePullPolicy() corev1.PullPolicy {
+	return Configs.RunnerImagePullPolicy
+}
+
 func getSinkRunnerImage(spec *v1alpha1.SinkSpec) string {
 	img := spec.Image
 	if img != "" {
@@ -1950,6 +1966,14 @@ func getSinkRunnerImage(spec *v1alpha1.SinkSpec) string {
 		return Configs.RunnerImages.Java
 	}
 	return DefaultRunnerImage
+}
+
+func getSourceRunnerImagePullSecret() []map[string]string {
+	return Configs.RunnerImagePullSecrets
+}
+
+func getSourceRunnerImagePullPolicy() corev1.PullPolicy {
+	return Configs.RunnerImagePullPolicy
 }
 
 func getSourceRunnerImage(spec *v1alpha1.SourceSpec) string {

--- a/controllers/spec/controller_configs.go
+++ b/controllers/spec/controller_configs.go
@@ -20,6 +20,7 @@ package spec
 import (
 	"os"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -31,9 +32,11 @@ type RunnerImages struct {
 }
 
 type ControllerConfigs struct {
-	RunnerImages        RunnerImages      `yaml:"runnerImages,omitempty"`
-	ResourceLabels      map[string]string `yaml:"resourceLabels,omitempty"`
-	ResourceAnnotations map[string]string `yaml:"resourceAnnotations,omitempty"`
+	RunnerImages           RunnerImages        `yaml:"runnerImages,omitempty"`
+	RunnerImagePullSecrets []map[string]string `yaml:"runnerImagePullSecrets,omitempty"`
+	RunnerImagePullPolicy  corev1.PullPolicy   `yaml:"imagePullPolicy,omitempty"`
+	ResourceLabels         map[string]string   `yaml:"resourceLabels,omitempty"`
+	ResourceAnnotations    map[string]string   `yaml:"resourceAnnotations,omitempty"`
 }
 
 var Configs = DefaultConfigs()


### PR DESCRIPTION


### Motivation

While working with FunctionMesh, we observed that the runner image could only be configured by specifying its repository. In our intranet environment, where all Docker images are used privately, it is essential to always define ImagePullSecrets.

This modification was aimed at ensuring that ImagePullSecrets and ImagePullPolicy can also be specified when downloading the modified runnerImage.

Additionally, we aligned this update with the existing functionality by placing the base runner image configuration within the values.yaml file of the Function Controller, maintaining consistency with the current setup.

### Modifications
The modification ensures that when the FunctionMesh Controller uses the Kubernetes library to create StatefulSets for Functions, Sinks, and Sources, the ImagePullSecrets and ImagePullPolicy configurations are properly propagated to the associated POD settings.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.


  - To validate this feature, we deployed the FunctionMesh Controller directly on our existing Pulsar cluster and conducted various tests to ensure its functionality.
  - We verified that the FunctionMesh Controller correctly applies the ImagePullSecret and ImagePullPolicy configurations for the runner and confirmed that there were no issues with other core functionalities. This was validated by building and testing both the Master Branch and branch-0.22.

### Documentation

Check the box below.

Need to update docs? 

- [X] `doc-required` 
  
I think following README.md file should me modified to provide information about runner image configuration 
- https://github.com/streamnative/function-mesh/blob/master/charts/function-mesh-operator/README.md