### PR TITLE
Copy Kinesis KPL 1.0.4 binary into the image

### DIFF
--- a/images/pulsar-functions-base-runner/Dockerfile
+++ b/images/pulsar-functions-base-runner/Dockerfile
@@ -2,6 +2,7 @@ ARG PULSAR_IMAGE
 ARG PULSAR_IMAGE_TAG
 FROM ${PULSAR_IMAGE}:${PULSAR_IMAGE_TAG} as pulsar
 FROM apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:0.15.12 as pulsar-io-kinesis-sink-kinesis_producer
+FROM apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:1.0.4 as pulsar-io-kinesis-sink-kinesis_producer-1.0
 FROM alpine:3.21 as functions-runner
 
 ENV GID=10001
@@ -73,6 +74,10 @@ ENV java.io.tmpdir=/pulsar/tmp/
 COPY --from=pulsar-io-kinesis-sink-kinesis_producer --chown=$UID:$GID /opt/amazon-kinesis-producer/bin/kinesis_producer /opt/amazon-kinesis-producer/bin/.os_info /opt/amazon-kinesis-producer/bin/.build_time /opt/amazon-kinesis-producer/bin/.revision /opt/amazon-kinesis-producer/bin/.system_info /opt/amazon-kinesis-producer/bin/.version /opt/amazon-kinesis-producer/bin/
 # Set the environment variable to point to the kinesis_producer native executable
 ENV PULSAR_IO_KINESIS_KPL_PATH=/opt/amazon-kinesis-producer/bin/kinesis_producer
+# Copy the 1.0 version of the kinesis_producer native executable
+COPY --from=pulsar-io-kinesis-sink-kinesis_producer-1.0 --chown=$UID:$GID /opt/amazon-kinesis-producer/bin/kinesis_producer /opt/amazon-kinesis-producer/bin/.os_info /opt/amazon-kinesis-producer/bin/.build_time /opt/amazon-kinesis-producer/bin/.revision /opt/amazon-kinesis-producer/bin/.system_info /opt/amazon-kinesis-producer/bin/.version /opt/amazon-kinesis-producer-1.0/bin/
+# Set the environment variable to point to the 1.0 version of the kinesis_producer native executable
+ENV PULSAR_IO_KINESIS_KPL_1_0_PATH=/opt/amazon-kinesis-producer-1.0/bin/kinesis_producer
 # Install the required dependencies for the kinesis_producer native executable
 USER 0
 RUN apk update && apk add --no-cache \

--- a/images/pulsar-functions-java-runner/pulsarctl.Dockerfile
+++ b/images/pulsar-functions-java-runner/pulsarctl.Dockerfile
@@ -2,6 +2,7 @@ ARG PULSAR_IMAGE
 ARG PULSAR_IMAGE_TAG
 FROM ${PULSAR_IMAGE}:${PULSAR_IMAGE_TAG} as pulsar
 FROM apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:0.15.12 as pulsar-io-kinesis-sink-kinesis_producer
+FROM apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:1.0.4 as pulsar-io-kinesis-sink-kinesis_producer-1.0
 FROM pulsar-functions-pulsarctl-runner-base:latest
 
 ARG PULSAR_IMAGE_TAG
@@ -62,6 +63,10 @@ WORKDIR /pulsar
 COPY --from=pulsar-io-kinesis-sink-kinesis_producer --chown=$UID:$GID /opt/amazon-kinesis-producer/bin/kinesis_producer /opt/amazon-kinesis-producer/bin/.os_info /opt/amazon-kinesis-producer/bin/.build_time /opt/amazon-kinesis-producer/bin/.revision /opt/amazon-kinesis-producer/bin/.system_info /opt/amazon-kinesis-producer/bin/.version /opt/amazon-kinesis-producer/bin/
 # Set the environment variable to point to the kinesis_producer native executable
 ENV PULSAR_IO_KINESIS_KPL_PATH=/opt/amazon-kinesis-producer/bin/kinesis_producer
+# Copy the 1.0 version of the kinesis_producer native executable
+COPY --from=pulsar-io-kinesis-sink-kinesis_producer-1.0 --chown=$UID:$GID /opt/amazon-kinesis-producer/bin/kinesis_producer /opt/amazon-kinesis-producer/bin/.os_info /opt/amazon-kinesis-producer/bin/.build_time /opt/amazon-kinesis-producer/bin/.revision /opt/amazon-kinesis-producer/bin/.system_info /opt/amazon-kinesis-producer/bin/.version /opt/amazon-kinesis-producer-1.0/bin/
+# Set the environment variable to point to the 1.0 version of the kinesis_producer native executable
+ENV PULSAR_IO_KINESIS_KPL_1_0_PATH=/opt/amazon-kinesis-producer-1.0/bin/kinesis_producer
 # Install the required dependencies for the kinesis_producer native executable
 USER 0
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
### Motivation & Modifications

To support AWS Kinesis Producer Library (KPL) 1.0, it's necessary to also copy the 1.0.4 native binary into the image and set the `PULSAR_IO_KINESIS_KPL_1_0_PATH` environment variable.
On Pulsar side this depends on these PRs:
* https://github.com/apache/pulsar/pull/24661
* https://github.com/apache/pulsar/pull/24669

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

