### PR TITLE
fix: remove pause-rollout=false

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,6 @@ spec:
         - "--namespaced-backend-config=backend-config"
         - "--global-backend-config=global-backend-config"
         - "--global-backend-config-namespace=sn-system"
-        - "--pause-rollout=false"
         ports:
           - containerPort: 8443
             name: metrics

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,7 +36,6 @@ spec:
         - --namespaced-backend-config=backend-config
         - --global-backend-config=global-backend-config
         - --global-backend-config-namespace=sn-system
-        - --pause-rollout=false
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
### Motivation

Set --pause-rollout=false in manager will make it un-configurable

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

